### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 1.1.0 (2017-12-04)
+==========================
 
 - Added tests for the validators mapping
 - Minor syntax changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+master (unreleased)
+===================
+
+Nothing here yet.
+
 Release 1.1.0 (2017-12-04)
 ==========================
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -4,5 +4,5 @@ from .json_migrations import latest_version
 
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.1.0'
+version = '1.2.0.dev0'
 json_version = latest_version

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -4,5 +4,5 @@ from .json_migrations import latest_version
 
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.1.0.dev0'
+version = '1.1.0'
 json_version = latest_version


### PR DESCRIPTION

### Changelog:

- Added tests for the validators mapping
- Minor syntax changes
- Added perf rec tests
- Add configuration for py.test
- Reactivate accidentally skipped ``test_validations.py`` tests
- Add JSON migrations
- ``FormidableItem.value`` field size now has no limit (``TextField``)
- Migrate to PeopleDoc GitHub organization (#283)

## Release

* [x] ~~Fetch translations from Crowdin~~ skipped, no new translation
* [x] Change VERSION with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [ ] Tag the resulting commit with the appropriate tag
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
