### PR TITLE
[Doc] Fixed a missing ``cd`` in docs. You can't run pytest from project root.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- [Documentation] Fixed a missing ``cd`` in docs. You can't run pytest from project root (#293).
 
 Release 1.2.1 (2018-01-12)
 ==========================

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -61,6 +61,7 @@ We've added a section in our ``setup.cfg``, so you should be able to run tests s
 
 .. code:: shell
 
+    $ cd demo/
     $ py.test
 
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from .json_migrations import latest_version
 
-
 default_app_config = 'formidable.app.FormidableConfig'
 version = '1.3.0.dev0'
 json_version = latest_version


### PR DESCRIPTION
Before:

```sh
$ cd project/root/directory
$ pytest
[..]
ImportError: No module named demo.settings

pytest-django could not find a Django project (no manage.py file could be found). You must explicitly add your Django project to the Python path to have it picked up.
```

What we need is to go to the `demo` directory in order to have the Django Settings Module correctly picked up.