### PR TITLE
Disallow GET method for user-data validation URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Added tests against the ``formidable.yml`` schema definition of Forms (#295).
 - Fixed various items in the schema definition (#297).
+- Validation endpoint for **user data** doesn't allow GET method anymore (#300).
 
 Release 1.3.0 (2018-02-14)
 ==========================

--- a/demo/tests/test_integration.py
+++ b/demo/tests/test_integration.py
@@ -391,14 +391,10 @@ class MyForm(FormidableForm):
 class TestValidationEndPoint(FormidableAPITestCase):
 
     url = 'formidable:form_validation'
-    method = 'get'
 
     def setUp(self):
         super(TestValidationEndPoint, self).setUp()
         self.formidable = MyForm.to_formidable(label='title')
-
-    def get_method(self):
-        return getattr(self.client, self.method)
 
     def test_validate_data_ok(self):
         parameters = {
@@ -408,8 +404,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session = self.client.session
         session['role'] = 'padawan'
         session.save()
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[self.formidable.pk]),
             parameters, format='json'
         )
@@ -424,8 +419,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session = self.client.session
         session['role'] = 'padawan'
         session.save()
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[9999]),
             parameters, format='json'
         )
@@ -438,8 +432,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session = self.client.session
         session['role'] = 'padawan'
         session.save()
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[self.formidable.pk]),
             parameters, format='json'
         )
@@ -459,8 +452,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
         session = self.client.session
         session['role'] = 'padawan'
         session.save()
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[formidable.pk]),
             parameters, format='json'
         )
@@ -501,8 +493,7 @@ class TestValidationEndPoint(FormidableAPITestCase):
 
         # The checkbox is checked.
         parameters = {'checkbox': True}
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[formidable.pk]),
             parameters, format='json'
         )
@@ -512,20 +503,28 @@ class TestValidationEndPoint(FormidableAPITestCase):
 
         # The checkbox is NOT checked.
         parameters = {'checkbox': False}
-        func = self.get_method()
-        res = func(
+        res = self.client.post(
             reverse(self.url, args=[formidable.pk]),
             parameters, format='json'
         )
         # We still don't validate file fields.
         self.assertEqual(res.status_code, 204)
 
+    def test_unallowed_method(self):
+        parameters = {
+            'first_name': 'Guillaume',
+            'last_name': 'Gérard',
+        }
+        session = self.client.session
+        session['role'] = 'padawan'
+        session.save()
+        # As of 1.4.0, GET is disallowed.
+        res = self.client.get(
+            reverse(self.url, args=[self.formidable.pk]),
+            parameters, format='json'
+        )
+        self.assertEqual(res.status_code, 405)
+
 
 class TestValidationFromSchemaEndPoint(TestValidationEndPoint):
-
     url = 'form_validation_schema'
-
-
-class TestValidationWithPostMethod(TestValidationEndPoint):
-
-    method = 'post'

--- a/demo/tests/test_perfs_rec.py
+++ b/demo/tests/test_perfs_rec.py
@@ -108,7 +108,7 @@ class TestPerfRec(TestCase):
 
         with self.record_performance(record_name='validate-form'):
             url = reverse('formidable:form_validation', args=(form_id,))
-            self.client.get(url)
+            self.client.post(url)
 
     def _create_form(self):
         session = self.client.session

--- a/docs/source/_static/specs/formidable.js
+++ b/docs/source/_static/specs/formidable.js
@@ -512,28 +512,6 @@ var spec = {
             }
         },
         "/forms/{id}/validate/": {
-            "get": {
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "type": "integer"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Validation OK"
-                    },
-                    "400": {
-                        "description": "Validation KO",
-                        "schema": {
-                            "$ref": "#/definitions/InputError"
-                        }
-                    }
-                },
-                "summary": "Validate a form (GET method). GET and POST are equivalent, but GET is deprecated."
-            },
             "post": {
                 "parameters": [
                     {
@@ -554,7 +532,7 @@ var spec = {
                         }
                     }
                 },
-                "summary": "Validate a form (POST method). GET and POST are equivalent."
+                "summary": "Validate user-data against a form schema."
             }
         }
     },

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,6 +2,16 @@
 Deprecation timeline
 ====================
 
+From 1.3.0 to 1.4.0
+===================
+
+Validation endpoint
+-------------------
+
+.. deprecated:: 1.4.0
+
+    Validation endpoint for **user data** doesn't allow GET method anymore.
+
 From 0.15 to 1.0.0
 ==================
 

--- a/docs/swagger/formidable.yml
+++ b/docs/swagger/formidable.yml
@@ -132,22 +132,8 @@ paths:
             $ref: '#/definitions/BuilderForm'
 
   /forms/{id}/validate/:
-    get:
-      summary: Validate a form (GET method). GET and POST are equivalent, but GET is deprecated.
-      parameters:
-        - name: id
-          in: path
-          type: integer
-          required: true
-      responses:
-        204:
-          description:  Validation OK
-        400:
-          description: Validation KO
-          schema:
-            $ref: '#/definitions/InputError'
     post:
-      summary: Validate a form (POST method). GET and POST are equivalent.
+      summary: Validate user-data against a form schema.
       parameters:
         - name: id
           in: path

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import logging
-import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -252,16 +251,6 @@ class ValidateView(six.with_metaclass(MetaClassView,
             return self.form_valid(form)
         else:
             return self.form_invalid(form)
-
-    def get(self, request, **kwargs):
-        """
-        GET method is deprecated in favor of POST
-
-        """
-        warnings.warn('GET method for form validation has been deprecated in '
-                      'favor of POST. Please use POST instead of GET.',
-                      category=DeprecationWarning)
-        return self.post(request, **kwargs)
 
     def get_form_class(self, formidable):
         return formidable.get_django_form_class(


### PR DESCRIPTION
## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
  * [x] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
