### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 1.4.0 (2018-02-21)
+==========================
+
+**Deprecation Warning**: The validation endpoint (using the URL ``forms/(?P<pk>\d+)/validate/``) is now ``POST`` only.
 
 - Added tests against the ``formidable.yml`` schema definition of Forms (#295).
 - Fixed various items in the schema definition (#297).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+master (unreleased)
+===================
+
+Nothing here yet.
+
 Release 1.4.0 (2018-02-21)
 ==========================
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.4.0'
+version = '1.5.0.dev0'
 json_version = latest_version

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.4.0.dev0'
+version = '1.4.0'
 json_version = latest_version


### PR DESCRIPTION
### Changelog

**Deprecation Warning**: The validation endpoint (using the URL ``forms/(?P<pk>\d+)/validate/``) is now ``POST`` only.

- Added tests against the ``formidable.yml`` schema definition of Forms (#295).
- Fixed various items in the schema definition (#297).
- Validation endpoint for **user data** doesn't allow GET method anymore (#300).
- Add support for multiple conditions to target a common field.


## Release

* [x] Fetch translations from Crowdin -- done, nothing new apparently
* [x] Change VERSION with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [ ] Tag the resulting commit with the appropriate tag
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
