### PR TITLE
Add tests for conditional rules based on dropdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Trim whitespaces in the generated ``formidable.js`` file. This is more than just cosmetics, it prevents to have a polluted history on this file.
 - Added tests to use conditional rules with drop down lists
+- Added possibility to restrict types of the conditional rules
 - Hotfix: Extract conditions and filter them using the fields that exist in the form.
 - Added typing to the demo requirements
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Trim whitespaces in the generated ``formidable.js`` file. This is more than just cosmetics, it prevents to have a polluted history on this file.
+- Added tests to use conditional rules with drop down lists
 - Hotfix: Extract conditions and filter them using the fields that exist in the form.
 - Added typing to the demo requirements
 

--- a/demo/tests/fixtures/drop-down-conditions.json
+++ b/demo/tests/fixtures/drop-down-conditions.json
@@ -1,0 +1,203 @@
+{
+	"label": "Drop Down Test Form",
+	"description": "Drop Down Test Form",
+	"fields": [{
+			"slug": "main_dropdown",
+			"label": "main_dropdown",
+			"type_id": "dropdown",
+			"placeholder": "main_dropdown",
+			"description": "main_dropdown",
+			"accesses": [{
+					"access_id": "padawan",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "robot",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi-master",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "human",
+					"level": "EDITABLE"
+				}
+			],
+			"validations": [],
+			"defaults": [],
+			"items": [{
+					"value": "first",
+					"label": "First",
+					"description": null
+				},
+				{
+					"value": "second",
+					"label": "Second",
+					"description": null
+				},
+				{
+					"value": "third",
+					"label": "Third",
+					"description": null
+				}
+			],
+			"multiple": false
+		},
+		{
+			"slug": "first_field",
+			"label": "first_field",
+			"type_id": "text",
+			"placeholder": "first_field",
+			"description": "first_field",
+			"accesses": [{
+					"access_id": "padawan",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "robot",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi-master",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "human",
+					"level": "EDITABLE"
+				}
+			],
+			"validations": [],
+			"defaults": []
+		},
+		{
+			"slug": "second_field",
+			"label": "second_field",
+			"type_id": "text",
+			"placeholder": "second_field",
+			"description": "second_field",
+			"accesses": [{
+					"access_id": "padawan",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "robot",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi-master",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "human",
+					"level": "EDITABLE"
+				}
+			],
+			"validations": [],
+			"defaults": []
+		},
+		{
+			"slug": "third_field",
+			"label": "third_field",
+			"type_id": "text",
+			"placeholder": null,
+			"description": "",
+			"accesses": [{
+					"access_id": "padawan",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "robot",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi-master",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "human",
+					"level": "EDITABLE"
+				}
+			],
+			"validations": [],
+			"defaults": []
+		},
+		{
+			"slug": "another_field",
+			"label": "another_field",
+			"type_id": "text",
+			"placeholder": "another_field",
+			"description": "another_field",
+			"accesses": [{
+					"access_id": "padawan",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "robot",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "jedi-master",
+					"level": "EDITABLE"
+				},
+				{
+					"access_id": "human",
+					"level": "EDITABLE"
+				}
+			],
+			"validations": [],
+			"defaults": []
+		}
+	],
+	"id": 1,
+	"conditions": [{
+			"name": "Show first and second if value 'first' selected",
+			"fields_ids": [
+				"first_field",
+				"second_field"
+			],
+			"action": "display_iff",
+			"tests": [{
+				"field_id": "main_dropdown",
+				"operator": "eq",
+				"values": [
+					"first"
+				]
+			}]
+		},
+		{
+			"name": "Show third if value 'second' selected",
+			"fields_ids": [
+				"third_field"
+			],
+			"action": "display_iff",
+			"tests": [{
+				"field_id": "main_dropdown",
+				"operator": "eq",
+				"values": [
+					"second"
+				]
+			}]
+		}
+	]
+}

--- a/demo/tests/fixtures/test_conditions.py
+++ b/demo/tests/fixtures/test_conditions.py
@@ -1,0 +1,76 @@
+from formidable.forms import (
+    FormidableForm, fields
+)
+from formidable import constants
+
+
+class DropdownConditionsTestCaseTestForm(FormidableForm):
+    checkbox_a = fields.BooleanField(
+        label='My checkbox',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.EDITABLE,
+                  'human': constants.EDITABLE,
+                  'robot': constants.REQUIRED}
+    )
+    checkbox_ab = fields.BooleanField(
+        label='My checkbox 2',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.EDITABLE,
+                  'human': constants.EDITABLE,
+                  'robot': constants.REQUIRED}
+    )
+    a = fields.CharField(
+        label='a',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.EDITABLE,
+                  'human': constants.REQUIRED,
+                  'robot': constants.REQUIRED}
+    )
+    b = fields.CharField(
+        label='b',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.EDITABLE,
+                  'human': constants.READONLY,
+                  'robot': constants.REQUIRED}
+    )
+
+
+class DropdownConditionsTestCaseDropDownForm(FormidableForm):
+    main_dropdown = fields.ChoiceField(
+        choices=(
+            ('ab', 'AB'),
+            ('b', 'B'),
+            ('no_condition', 'No_condition')
+        ),
+        accesses={'padawan': constants.EDITABLE}
+    )
+    a = fields.CharField(
+        accesses={'padawan': constants.EDITABLE})
+    b = fields.CharField(
+        accesses={'padawan': constants.EDITABLE})
+    c = fields.CharField(
+        accesses={'padawan': constants.EDITABLE})
+
+
+class ConditionTestCaseTestForm(FormidableForm):
+    checkbox = fields.BooleanField(
+        label='My checkbox',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.EDITABLE,
+                  'human': constants.EDITABLE,
+                  'robot': constants.REQUIRED}
+    )
+    foo = fields.CharField(
+        label='Foo',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.REQUIRED,
+                  'human': constants.REQUIRED,
+                  'robot': constants.REQUIRED}
+    )
+    bar = fields.CharField(
+        label='Bar',
+        accesses={'padawan': constants.EDITABLE,
+                  'jedi': constants.REQUIRED,
+                  'human': constants.READONLY,
+                  'robot': constants.REQUIRED}
+    )

--- a/demo/tests/test_conditions.py
+++ b/demo/tests/test_conditions.py
@@ -219,6 +219,7 @@ class DropdownConditionsTestCase(TestCase):
         return get_dynamic_form_class(formidable, role)
 
     def setUp(self):
+        super(DropdownConditionsTestCase, self).setUp()
         conditions_schema = [
             {
                 'name': 'Show a and b if value "ab" selected',

--- a/demo/tests/test_conditions.py
+++ b/demo/tests/test_conditions.py
@@ -7,7 +7,7 @@ import json
 import copy
 
 from django.test import TestCase
-
+from django.test.utils import override_settings
 
 from formidable import constants
 
@@ -36,6 +36,7 @@ class ConditionTestCase(TestCase):
         ))
 
     def setUp(self):
+        super(ConditionTestCase, self).setUp()
         conditions_schema = [
             {
                 'name': 'My Name',
@@ -341,6 +342,7 @@ class MultipleConditionsTestCase(TestCase):
         return get_dynamic_form_class(formidable, role)
 
     def setUp(self):
+        super(MultipleConditionsTestCase, self).setUp()
         conditions_schema = [
             {
                 'name': 'display A',
@@ -498,6 +500,25 @@ class ConditionSerializerTestCase(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         instance = serializer.save()
         self.assertEqual(instance.conditions, self.payload['conditions'])
+
+    @override_settings(FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES=[])
+    def test_allowed_types_empty_settings(self):
+        serializer = FormidableSerializer(data=self.payload)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @override_settings(FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES=[
+        'checkbox', 'dropdown']
+    )
+    def test_allowed_types_accepted_settings(self):
+        serializer = FormidableSerializer(data=self.payload)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    @override_settings(
+        FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES=['type-does-not-exist']
+    )
+    def test_allowed_types_denied_settings(self):
+        serializer = FormidableSerializer(data=self.payload)
+        self.assertFalse(serializer.is_valid())
 
 
 class ConditionContextualizationTest(TestCase):

--- a/demo/tests/test_conditions.py
+++ b/demo/tests/test_conditions.py
@@ -235,7 +235,6 @@ class ConditionFromSchemaTestCase(ConditionTestCase):
         return get_dynamic_form_class_from_schema(schema)
 
 
-
 class DropdownConditionsTestCase(TestCase):
 
     def get_form_class(self, formidable, role):

--- a/demo/tests/test_conditions.py
+++ b/demo/tests/test_conditions.py
@@ -9,10 +9,10 @@ import copy
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from formidable import constants
+from tests.fixtures import test_conditions as test_conditions_fixtures
 
 from formidable.forms import (
-    FormidableForm, fields, get_dynamic_form_class,
+    get_dynamic_form_class,
     get_dynamic_form_class_from_schema
 )
 from formidable.serializers.forms import (
@@ -51,31 +51,8 @@ class ConditionTestCase(TestCase):
                 ]
             }
         ]
-
-        class TestForm(FormidableForm):
-            checkbox = fields.BooleanField(
-                label='My checkbox',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.EDITABLE,
-                          'human': constants.EDITABLE,
-                          'robot': constants.REQUIRED}
-            )
-            foo = fields.CharField(
-                label='Foo',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.REQUIRED,
-                          'human': constants.REQUIRED,
-                          'robot': constants.REQUIRED}
-            )
-            bar = fields.CharField(
-                label='Bar',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.REQUIRED,
-                          'human': constants.READONLY,
-                          'robot': constants.REQUIRED}
-            )
-
-        self.formidable = TestForm.to_formidable(label='title')
+        form_class = test_conditions_fixtures.ConditionTestCaseTestForm
+        self.formidable = form_class.to_formidable(label='title')
         self.formidable.conditions = conditions_schema
 
     def test_jedi_displayed(self):
@@ -269,23 +246,8 @@ class DropdownConditionsTestCase(TestCase):
             }
         ]
 
-        class DropDownForm(FormidableForm):
-            main_dropdown = fields.ChoiceField(
-                choices=(
-                    ('ab', 'AB'),
-                    ('b', 'B'),
-                    ('no_condition', 'No_condition')
-                ),
-                accesses={'padawan': constants.EDITABLE}
-            )
-            a = fields.CharField(
-                accesses={'padawan': constants.EDITABLE})
-            b = fields.CharField(
-                accesses={'padawan': constants.EDITABLE})
-            c = fields.CharField(
-                accesses={'padawan': constants.EDITABLE})
-
-        self.formidable = DropDownForm.to_formidable(
+        form_class = test_conditions_fixtures.DropdownConditionsTestCaseDropDownForm  # noqa
+        self.formidable = form_class.to_formidable(
             label='Drop Down Test Form')
         self.formidable.conditions = conditions_schema
 
@@ -370,38 +332,8 @@ class MultipleConditionsTestCase(TestCase):
             }
 
         ]
-
-        class TestForm(FormidableForm):
-            checkbox_a = fields.BooleanField(
-                label='My checkbox',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.EDITABLE,
-                          'human': constants.EDITABLE,
-                          'robot': constants.REQUIRED}
-            )
-            checkbox_ab = fields.BooleanField(
-                label='My checkbox 2',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.EDITABLE,
-                          'human': constants.EDITABLE,
-                          'robot': constants.REQUIRED}
-            )
-            a = fields.CharField(
-                label='a',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.EDITABLE,
-                          'human': constants.REQUIRED,
-                          'robot': constants.REQUIRED}
-            )
-            b = fields.CharField(
-                label='b',
-                accesses={'padawan': constants.EDITABLE,
-                          'jedi': constants.EDITABLE,
-                          'human': constants.READONLY,
-                          'robot': constants.REQUIRED}
-            )
-
-        self.formidable = TestForm.to_formidable(label='title')
+        test_form = test_conditions_fixtures.DropdownConditionsTestCaseTestForm
+        self.formidable = test_form.to_formidable(label='title')
         self.formidable.conditions = conditions_schema
 
     def test_a_and_ab_checked(self):

--- a/docs/source/_static/specs/formidable.js
+++ b/docs/source/_static/specs/formidable.js
@@ -1,546 +1,546 @@
 var spec = {
-    "basePath": "/api", 
+    "basePath": "/api",
     "definitions": {
         "Access": {
-            "description": "Different contexts that helps to render a form", 
+            "description": "Different contexts that helps to render a form",
             "properties": {
                 "description": {
-                    "description": "Help text of the access", 
+                    "description": "Help text of the access",
                     "type": "string"
-                }, 
+                },
                 "id": {
-                    "description": "ID of the access", 
+                    "description": "ID of the access",
                     "type": "string"
-                }, 
+                },
                 "label": {
-                    "description": "Label of the access", 
+                    "description": "Label of the access",
                     "type": "string"
-                }, 
+                },
                 "preview_as": {
-                    "description": "How to display the preview, default is `FORM`. Values are `FORM`, `TABLE`", 
+                    "description": "How to display the preview, default is `FORM`. Values are `FORM`, `TABLE`",
                     "enum": [
-                        "FORM", 
+                        "FORM",
                         "TABLE"
-                    ], 
+                    ],
                     "type": "string"
                 }
-            }, 
+            },
             "required": [
-                "id", 
-                "label", 
+                "id",
+                "label",
                 "description"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "BuilderError": {
             "properties": {
                 "fields": {
-                    "description": "Errors on fields (key => field; value => list of messages)", 
+                    "description": "Errors on fields (key => field; value => list of messages)",
                     "type": "object"
-                }, 
+                },
                 "non_field_errors": {
-                    "description": "Errors on anything except fields (validations...)", 
+                    "description": "Errors on anything except fields (validations...)",
                     "items": {
                         "type": "string"
-                    }, 
+                    },
                     "type": "array"
                 }
-            }, 
+            },
             "type": "object"
-        }, 
+        },
         "BuilderForm": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Form"
-                }, 
+                },
                 {
                     "properties": {
                         "fields": {
-                            "description": "List of fields ordered in the form", 
+                            "description": "List of fields ordered in the form",
                             "items": {
                                 "$ref": "#/definitions/Field"
-                            }, 
+                            },
                             "type": "array"
                         }
                     }
                 }
             ]
-        }, 
+        },
         "Condition": {
-            "description": "Describe conditional display of a field, depending on the value of another field.\n\ne.g.: \"display the field 'what is you favorite Star Wars character?' if the boolean field 'Do you like Star Wars?' is checked\".\n", 
+            "description": "Describe conditional display of a field, depending on the value of another field.\n\ne.g.: \"display the field 'what is you favorite Star Wars character?' if the boolean field 'Do you like Star Wars?' is checked\".\n",
             "properties": {
                 "action": {
-                    "description": "Name of the action to do when the condition is true. e.g. \"display the field\" == ``display_iff``", 
+                    "description": "Name of the action to do when the condition is true. e.g. \"display the field\" == ``display_iff``",
                     "enum": [
                         "display_iff"
-                    ], 
+                    ],
                     "type": "string"
-                }, 
+                },
                 "field_ids": {
-                    "description": "List of field slugs to show/hide depending on the conditions.", 
+                    "description": "List of field slugs to show/hide depending on the conditions.",
                     "items": {
                         "type": "string"
-                    }, 
-                    "minItems": 1, 
+                    },
+                    "minItems": 1,
                     "type": "array"
-                }, 
+                },
                 "name": {
-                    "description": "A user-provided name for the Condition", 
+                    "description": "A user-provided name for the Condition",
                     "type": "string"
-                }, 
+                },
                 "tests": {
-                    "description": "List of conditions to test.", 
+                    "description": "List of conditions to test.",
                     "items": {
                         "$ref": "#/definitions/ConditionTest"
-                    }, 
-                    "minItems": 1, 
+                    },
+                    "minItems": 1,
                     "type": "array"
                 }
-            }, 
+            },
             "required": [
-                "name", 
-                "field_ids", 
-                "action", 
+                "name",
+                "field_ids",
+                "action",
                 "tests"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "ConditionTest": {
-            "description": "Condition definition.", 
+            "description": "Condition definition.",
             "properties": {
                 "field_id": {
-                    "description": "\\`slug\\` of the reference field for the comparison.", 
+                    "description": "\\`slug\\` of the reference field for the comparison.",
                     "type": "string"
-                }, 
+                },
                 "operator": {
-                    "description": "Comparison operator for the condition.", 
+                    "description": "Comparison operator for the condition.",
                     "enum": [
                         "eq"
-                    ], 
+                    ],
                     "type": "string"
-                }, 
+                },
                 "values": {
-                    "description": "List of the possible values that would return a \"true\" condition.", 
-                    "items": {}, 
+                    "description": "List of the possible values that would return a \"true\" condition.",
+                    "items": {},
                     "type": "array"
                 }
-            }, 
+            },
             "required": [
-                "field_id", 
-                "operator", 
+                "field_id",
+                "operator",
                 "values"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "Field": {
-            "description": "Field in a form", 
+            "description": "Field in a form",
             "properties": {
                 "accesses": {
-                    "description": "List of accesses of the field with a level", 
+                    "description": "List of accesses of the field with a level",
                     "items": {
                         "$ref": "#/definitions/FieldAccess"
-                    }, 
+                    },
                     "type": "array"
-                }, 
+                },
                 "defaults": {
-                    "description": "Default values selected/inputed when the form is newly displayed", 
+                    "description": "Default values selected/inputed when the form is newly displayed",
                     "items": {
                         "type": "string"
-                    }, 
+                    },
                     "type": "array"
-                }, 
+                },
                 "description": {
-                    "description": "Description of the field", 
+                    "description": "Description of the field",
                     "type": "string"
-                }, 
+                },
                 "id": {
-                    "description": "ID of the field", 
-                    "readOnly": true, 
+                    "description": "ID of the field",
+                    "readOnly": true,
                     "type": "integer"
-                }, 
+                },
                 "items": {
-                    "description": "Values available", 
+                    "description": "Values available",
                     "items": {
                         "$ref": "#/definitions/Item"
-                    }, 
+                    },
                     "type": "array"
-                }, 
+                },
                 "label": {
-                    "description": "Label of the field", 
+                    "description": "Label of the field",
                     "type": "string"
-                }, 
+                },
                 "multiple": {
-                    "description": "Is the field can have multiple values?", 
+                    "description": "Is the field can have multiple values?",
                     "type": "boolean"
-                }, 
+                },
                 "placeholder": {
-                    "description": "Placeholder of the field", 
+                    "description": "Placeholder of the field",
                     "type": "string"
-                }, 
+                },
                 "slug": {
-                    "description": "Slug of the field (us as uniq identifier of the field on the form)", 
+                    "description": "Slug of the field (us as uniq identifier of the field on the form)",
                     "type": "string"
-                }, 
+                },
                 "type_id": {
-                    "description": "Type of field (see Field types table)", 
+                    "description": "Type of field (see Field types table)",
                     "enum": [
-                        "title", 
-                        "helpText", 
-                        "fieldset", 
-                        "fieldsetTable", 
-                        "separation", 
-                        "checkbox", 
-                        "checkboxes", 
-                        "dropdown", 
-                        "radios", 
-                        "radiosButtons", 
-                        "text", 
-                        "paragraph", 
-                        "file", 
-                        "date", 
-                        "email", 
+                        "title",
+                        "helpText",
+                        "fieldset",
+                        "fieldsetTable",
+                        "separation",
+                        "checkbox",
+                        "checkboxes",
+                        "dropdown",
+                        "radios",
+                        "radiosButtons",
+                        "text",
+                        "paragraph",
+                        "file",
+                        "date",
+                        "email",
                         "number"
-                    ], 
+                    ],
                     "type": "string"
-                }, 
+                },
                 "validations": {
-                    "description": "List of validations of the field", 
+                    "description": "List of validations of the field",
                     "items": {
                         "$ref": "#/definitions/FieldValidation"
-                    }, 
+                    },
                     "type": "array"
                 }
-            }, 
+            },
             "required": [
-                "id", 
-                "slug", 
-                "label", 
-                "type_id", 
-                "description", 
+                "id",
+                "slug",
+                "label",
+                "type_id",
+                "description",
                 "accesses"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "FieldAccess": {
-            "description": "The access is the way to use the field in the context", 
+            "description": "The access is the way to use the field in the context",
             "properties": {
                 "access_id": {
-                    "description": "Access reference", 
+                    "description": "Access reference",
                     "type": "string"
-                }, 
+                },
                 "level": {
-                    "description": "Level of this access for the field", 
+                    "description": "Level of this access for the field",
                     "enum": [
-                        "REQUIRED", 
-                        "EDITABLE", 
-                        "HIDDEN", 
+                        "REQUIRED",
+                        "EDITABLE",
+                        "HIDDEN",
                         "READONLY"
-                    ], 
+                    ],
                     "type": "string"
                 }
-            }, 
+            },
             "required": [
-                "access_id", 
+                "access_id",
                 "level"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "FieldValidation": {
-            "description": "This validation can only be performed on a single field", 
+            "description": "This validation can only be performed on a single field",
             "properties": {
                 "message": {
-                    "description": "Error message if the validation is not verified", 
+                    "description": "Error message if the validation is not verified",
                     "type": "string"
-                }, 
+                },
                 "type": {
-                    "description": "Type of validation (see Validation types table)", 
+                    "description": "Type of validation (see Validation types table)",
                     "enum": [
-                        "EQ", 
-                        "GT", 
-                        "GTE", 
-                        "IS_AGE_ABOVE", 
-                        "IS_AGE_UNDER", 
-                        "IS_DATE_IN_THE_FUTURE", 
-                        "IS_DATE_IN_THE_PAST", 
-                        "LT", 
-                        "LTE", 
-                        "MAXLENGTH", 
-                        "MINLENGTH", 
-                        "NEQ", 
+                        "EQ",
+                        "GT",
+                        "GTE",
+                        "IS_AGE_ABOVE",
+                        "IS_AGE_UNDER",
+                        "IS_DATE_IN_THE_FUTURE",
+                        "IS_DATE_IN_THE_PAST",
+                        "LT",
+                        "LTE",
+                        "MAXLENGTH",
+                        "MINLENGTH",
+                        "NEQ",
                         "REGEXP"
-                    ], 
+                    ],
                     "type": "string"
-                }, 
+                },
                 "value": {
-                    "description": "Value of the validation", 
+                    "description": "Value of the validation",
                     "type": "string"
                 }
-            }, 
+            },
             "required": [
-                "type", 
+                "type",
                 "value"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "Form": {
-            "description": "The central piece of this project", 
+            "description": "The central piece of this project",
             "properties": {
                 "conditions": {
                     "items": {
                         "$ref": "#/definitions/Condition"
-                    }, 
+                    },
                     "type": "array"
-                }, 
+                },
                 "description": {
-                    "description": "Description of the form", 
+                    "description": "Description of the form",
                     "type": "string"
-                }, 
+                },
                 "id": {
-                    "description": "ID of the form", 
-                    "readOnly": true, 
+                    "description": "ID of the form",
+                    "readOnly": true,
                     "type": "integer"
-                }, 
+                },
                 "label": {
-                    "description": "Title of the form", 
+                    "description": "Title of the form",
                     "type": "string"
                 }
-            }, 
+            },
             "required": [
-                "id", 
-                "label", 
+                "id",
+                "label",
                 "description"
-            ], 
+            ],
             "type": "object"
-        }, 
+        },
         "InputError": {
-            "description": "Object that contains field errors as key with a list of string in value", 
+            "description": "Object that contains field errors as key with a list of string in value",
             "properties": {
                 "__all__": {
-                    "description": "Errors on anything except form's fields", 
+                    "description": "Errors on anything except form's fields",
                     "items": {
                         "type": "string"
-                    }, 
+                    },
                     "type": "array"
                 }
-            }, 
+            },
             "type": "object"
-        }, 
+        },
         "InputField": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Field"
                 }
-            ], 
+            ],
             "properties": {
                 "values": {
-                    "description": "Values selected/inputed when the form is in edition mode", 
+                    "description": "Values selected/inputed when the form is in edition mode",
                     "items": {
                         "type": "string"
-                    }, 
+                    },
                     "type": "array"
                 }
             }
-        }, 
+        },
         "InputForm": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Form"
-                }, 
+                },
                 {
                     "properties": {
                         "fields": {
-                            "description": "List of fields ordered in the form", 
+                            "description": "List of fields ordered in the form",
                             "items": {
                                 "$ref": "#/definitions/InputField"
-                            }, 
+                            },
                             "type": "array"
                         }
                     }
                 }
             ]
-        }, 
+        },
         "Item": {
-            "description": "Describe an item in a list", 
+            "description": "Describe an item in a list",
             "properties": {
                 "description": {
-                    "description": "Description of the item", 
+                    "description": "Description of the item",
                     "type": "string"
-                }, 
+                },
                 "label": {
-                    "description": "Label of the item", 
+                    "description": "Label of the item",
                     "type": "string"
-                }, 
+                },
                 "value": {
-                    "description": "Value which defined the item", 
+                    "description": "Value which defined the item",
                     "type": "string"
                 }
-            }, 
+            },
             "required": [
-                "label", 
+                "label",
                 "value"
-            ], 
+            ],
             "type": "object"
         }
-    }, 
-    "host": "localhost:8000", 
+    },
+    "host": "localhost:8000",
     "info": {
-        "description": "django-formidable is a full django application which allows you to create,\nedit, delete and use forms.\n\n##### Field types\n\nList of known types available:\n\n| Type | Description | HTML Component |\n| ---- | ----------- | -------------- |\n| title | Title | h2 |\n| helpText | Helptext | p |\n| fieldset | Group of fields (iterable) | fieldset |\n| fieldsetTable | Group of fields display as table (iterable) | table |\n| separation | Separator line (design only) | hr |\n| checkbox | Checkbox alone | input type=checkbox |\n| checkboxes | Some checkboxes, all checkable | input type=checkbox, all have the same name |\n| dropdown | Dropdown with values | select |\n| radios | Some radios, only one is selected at once | input type=radio |\n| radiosButtons | Some radios display as toggle button | input type=radio |\n| text | Input for one line text | input type=text |\n| paragraph | Input for multiline text | textarea |\n| file | Field to select a local file to be uploaded | input type=file |\n| date | Input for a date (datepicker with it, lang know by application parameter, validation by momentjs) | input type=date |\n| email | Input for an email (validation by regexp) | input |\n| number | Input for a number | input |\n\n##### Validations types\n\nList of validations available by types:\n\n| Field | Validation type |\n| ----- | ----------- |\n| text | MINLENGTH, MAXLENGTH, REGEXP |\n| paragraph | MINLENGTH, MAXLENGTH, REGEXP |\n| date | GT, GTE, LT, LTE, EQ, NEQ, IS_AGE_ABOVE (>=), IS_AGE_UNDER (<), IS_DATE_IN_THE_PAST (< today), IS_DATE_IN_THE_FUTURE (< today) |\n| number | GT, GTE, LT, LTE, EQ, NEQ |\n", 
-        "title": "Formidable API", 
+        "description": "django-formidable is a full django application which allows you to create,\nedit, delete and use forms.\n\n##### Field types\n\nList of known types available:\n\n| Type | Description | HTML Component |\n| ---- | ----------- | -------------- |\n| title | Title | h2 |\n| helpText | Helptext | p |\n| fieldset | Group of fields (iterable) | fieldset |\n| fieldsetTable | Group of fields display as table (iterable) | table |\n| separation | Separator line (design only) | hr |\n| checkbox | Checkbox alone | input type=checkbox |\n| checkboxes | Some checkboxes, all checkable | input type=checkbox, all have the same name |\n| dropdown | Dropdown with values | select |\n| radios | Some radios, only one is selected at once | input type=radio |\n| radiosButtons | Some radios display as toggle button | input type=radio |\n| text | Input for one line text | input type=text |\n| paragraph | Input for multiline text | textarea |\n| file | Field to select a local file to be uploaded | input type=file |\n| date | Input for a date (datepicker with it, lang know by application parameter, validation by momentjs) | input type=date |\n| email | Input for an email (validation by regexp) | input |\n| number | Input for a number | input |\n\n##### Validations types\n\nList of validations available by types:\n\n| Field | Validation type |\n| ----- | ----------- |\n| text | MINLENGTH, MAXLENGTH, REGEXP |\n| paragraph | MINLENGTH, MAXLENGTH, REGEXP |\n| date | GT, GTE, LT, LTE, EQ, NEQ, IS_AGE_ABOVE (>=), IS_AGE_UNDER (<), IS_DATE_IN_THE_PAST (< today), IS_DATE_IN_THE_FUTURE (< today) |\n| number | GT, GTE, LT, LTE, EQ, NEQ |\n",
+        "title": "Formidable API",
         "version": "1.0.0"
-    }, 
+    },
     "paths": {
         "/builder/accesses/": {
             "get": {
-                "description": "List of accesses available.", 
+                "description": "List of accesses available.",
                 "responses": {
                     "200": {
-                        "description": "A list of accesses", 
+                        "description": "A list of accesses",
                         "schema": {
                             "items": {
                                 "$ref": "#/definitions/Access"
-                            }, 
+                            },
                             "type": "array"
                         }
                     }
-                }, 
+                },
                 "summary": "Get accesses"
             }
-        }, 
+        },
         "/builder/forms/": {
             "post": {
-                "description": "Create Form Description", 
+                "description": "Create Form Description",
                 "parameters": [
                     {
-                        "in": "body", 
-                        "name": "form", 
-                        "required": true, 
+                        "in": "body",
+                        "name": "form",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                ], 
+                ],
                 "responses": {
                     "201": {
-                        "description": "Newly created form", 
+                        "description": "Newly created form",
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
-                    }, 
+                    },
                     "400": {
-                        "description": "Unexpected error", 
+                        "description": "Unexpected error",
                         "schema": {
                             "$ref": "#/definitions/BuilderError"
                         }
                     }
-                }, 
+                },
                 "summary": "Create a new form"
             }
-        }, 
+        },
         "/builder/forms/{id}/": {
             "get": {
                 "parameters": [
                     {
-                        "in": "path", 
-                        "name": "id", 
-                        "required": true, 
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
                         "type": "integer"
                     }
-                ], 
+                ],
                 "responses": {
                     "200": {
-                        "description": "Form", 
+                        "description": "Form",
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                }, 
+                },
                 "summary": "Retrieve a Form"
-            }, 
+            },
             "put": {
                 "parameters": [
                     {
-                        "in": "path", 
-                        "name": "id", 
-                        "required": true, 
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
                         "type": "integer"
-                    }, 
+                    },
                     {
-                        "in": "body", 
-                        "name": "form", 
-                        "required": true, 
+                        "in": "body",
+                        "name": "form",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                ], 
+                ],
                 "responses": {
                     "200": {
-                        "description": "Form", 
+                        "description": "Form",
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
-                    }, 
+                    },
                     "400": {
-                        "description": "Unexpected error", 
+                        "description": "Unexpected error",
                         "schema": {
                             "$ref": "#/definitions/BuilderError"
                         }
                     }
-                }, 
+                },
                 "summary": "Update a Form"
             }
-        }, 
+        },
         "/forms/{id}/": {
             "get": {
                 "parameters": [
                     {
-                        "in": "path", 
-                        "name": "id", 
-                        "required": true, 
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
                         "type": "integer"
                     }
-                ], 
+                ],
                 "responses": {
                     "200": {
-                        "description": "A form", 
+                        "description": "A form",
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                }, 
+                },
                 "summary": "Get a contextualized form"
             }
-        }, 
+        },
         "/forms/{id}/validate/": {
             "post": {
                 "parameters": [
                     {
-                        "in": "path", 
-                        "name": "id", 
-                        "required": true, 
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
                         "type": "integer"
                     }
-                ], 
+                ],
                 "responses": {
                     "204": {
                         "description": "Validation OK"
-                    }, 
+                    },
                     "400": {
-                        "description": "Validation KO", 
+                        "description": "Validation KO",
                         "schema": {
                             "$ref": "#/definitions/InputError"
                         }
                     }
-                }, 
+                },
                 "summary": "Validate user-data against a form schema."
             }
         }
-    }, 
+    },
     "produces": [
         "application/json"
-    ], 
+    ],
     "schemes": [
         "http"
-    ], 
+    ],
     "swagger": "2.0"
 }

--- a/docs/source/_static/specs/formidable.js
+++ b/docs/source/_static/specs/formidable.js
@@ -1,546 +1,546 @@
 var spec = {
-    "basePath": "/api",
+    "basePath": "/api", 
     "definitions": {
         "Access": {
-            "description": "Different contexts that helps to render a form",
+            "description": "Different contexts that helps to render a form", 
             "properties": {
                 "description": {
-                    "description": "Help text of the access",
+                    "description": "Help text of the access", 
                     "type": "string"
-                },
+                }, 
                 "id": {
-                    "description": "ID of the access",
+                    "description": "ID of the access", 
                     "type": "string"
-                },
+                }, 
                 "label": {
-                    "description": "Label of the access",
+                    "description": "Label of the access", 
                     "type": "string"
-                },
+                }, 
                 "preview_as": {
-                    "description": "How to display the preview, default is `FORM`. Values are `FORM`, `TABLE`",
+                    "description": "How to display the preview, default is `FORM`. Values are `FORM`, `TABLE`", 
                     "enum": [
-                        "FORM",
+                        "FORM", 
                         "TABLE"
-                    ],
+                    ], 
                     "type": "string"
                 }
-            },
+            }, 
             "required": [
-                "id",
-                "label",
+                "id", 
+                "label", 
                 "description"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "BuilderError": {
             "properties": {
                 "fields": {
-                    "description": "Errors on fields (key => field; value => list of messages)",
+                    "description": "Errors on fields (key => field; value => list of messages)", 
                     "type": "object"
-                },
+                }, 
                 "non_field_errors": {
-                    "description": "Errors on anything except fields (validations...)",
+                    "description": "Errors on anything except fields (validations...)", 
                     "items": {
                         "type": "string"
-                    },
+                    }, 
                     "type": "array"
                 }
-            },
+            }, 
             "type": "object"
-        },
+        }, 
         "BuilderForm": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Form"
-                },
+                }, 
                 {
                     "properties": {
                         "fields": {
-                            "description": "List of fields ordered in the form",
+                            "description": "List of fields ordered in the form", 
                             "items": {
                                 "$ref": "#/definitions/Field"
-                            },
+                            }, 
                             "type": "array"
                         }
                     }
                 }
             ]
-        },
+        }, 
         "Condition": {
-            "description": "Describe conditional display of a field, depending on the value of another field.\n\ne.g.: \"display the field 'what is you favorite Star Wars character?' if the boolean field 'Do you like Star Wars?' is checked\".\n",
+            "description": "Describe conditional display of a field, depending on the value of another field.\n\ne.g.: \"display the field 'what is you favorite Star Wars character?' if the boolean field 'Do you like Star Wars?' is checked\".\n", 
             "properties": {
                 "action": {
-                    "description": "Name of the action to do when the condition is true. e.g. \"display the field\" == ``display_iff``",
+                    "description": "Name of the action to do when the condition is true. e.g. \"display the field\" == ``display_iff``", 
                     "enum": [
                         "display_iff"
-                    ],
+                    ], 
                     "type": "string"
-                },
+                }, 
                 "field_ids": {
-                    "description": "List of field slugs to show/hide depending on the conditions.",
+                    "description": "List of field slugs to show/hide depending on the conditions.", 
                     "items": {
                         "type": "string"
-                    },
-                    "minItems": 1,
+                    }, 
+                    "minItems": 1, 
                     "type": "array"
-                },
+                }, 
                 "name": {
-                    "description": "A user-provided name for the Condition",
+                    "description": "A user-provided name for the Condition", 
                     "type": "string"
-                },
+                }, 
                 "tests": {
-                    "description": "List of conditions to test.",
+                    "description": "List of conditions to test.", 
                     "items": {
                         "$ref": "#/definitions/ConditionTest"
-                    },
-                    "minItems": 1,
+                    }, 
+                    "minItems": 1, 
                     "type": "array"
                 }
-            },
+            }, 
             "required": [
-                "name",
-                "field_ids",
-                "action",
+                "name", 
+                "field_ids", 
+                "action", 
                 "tests"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "ConditionTest": {
-            "description": "Condition definition.",
+            "description": "Condition definition.", 
             "properties": {
                 "field_id": {
-                    "description": "\\`slug\\` of the reference field for the comparison.",
+                    "description": "\\`slug\\` of the reference field for the comparison.", 
                     "type": "string"
-                },
+                }, 
                 "operator": {
-                    "description": "Comparison operator for the condition.",
+                    "description": "Comparison operator for the condition.", 
                     "enum": [
                         "eq"
-                    ],
+                    ], 
                     "type": "string"
-                },
+                }, 
                 "values": {
-                    "description": "List of the possible values that would return a \"true\" condition.",
-                    "items": {},
+                    "description": "List of the possible values that would return a \"true\" condition.", 
+                    "items": {}, 
                     "type": "array"
                 }
-            },
+            }, 
             "required": [
-                "field_id",
-                "operator",
+                "field_id", 
+                "operator", 
                 "values"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "Field": {
-            "description": "Field in a form",
+            "description": "Field in a form", 
             "properties": {
                 "accesses": {
-                    "description": "List of accesses of the field with a level",
+                    "description": "List of accesses of the field with a level", 
                     "items": {
                         "$ref": "#/definitions/FieldAccess"
-                    },
+                    }, 
                     "type": "array"
-                },
+                }, 
                 "defaults": {
-                    "description": "Default values selected/inputed when the form is newly displayed",
+                    "description": "Default values selected/inputed when the form is newly displayed", 
                     "items": {
                         "type": "string"
-                    },
+                    }, 
                     "type": "array"
-                },
+                }, 
                 "description": {
-                    "description": "Description of the field",
+                    "description": "Description of the field", 
                     "type": "string"
-                },
+                }, 
                 "id": {
-                    "description": "ID of the field",
-                    "readOnly": true,
+                    "description": "ID of the field", 
+                    "readOnly": true, 
                     "type": "integer"
-                },
+                }, 
                 "items": {
-                    "description": "Values available",
+                    "description": "Values available", 
                     "items": {
                         "$ref": "#/definitions/Item"
-                    },
+                    }, 
                     "type": "array"
-                },
+                }, 
                 "label": {
-                    "description": "Label of the field",
+                    "description": "Label of the field", 
                     "type": "string"
-                },
+                }, 
                 "multiple": {
-                    "description": "Is the field can have multiple values?",
+                    "description": "Is the field can have multiple values?", 
                     "type": "boolean"
-                },
+                }, 
                 "placeholder": {
-                    "description": "Placeholder of the field",
+                    "description": "Placeholder of the field", 
                     "type": "string"
-                },
+                }, 
                 "slug": {
-                    "description": "Slug of the field (us as uniq identifier of the field on the form)",
+                    "description": "Slug of the field (us as uniq identifier of the field on the form)", 
                     "type": "string"
-                },
+                }, 
                 "type_id": {
-                    "description": "Type of field (see Field types table)",
+                    "description": "Type of field (see Field types table)", 
                     "enum": [
-                        "title",
-                        "helpText",
-                        "fieldset",
-                        "fieldsetTable",
-                        "separation",
-                        "checkbox",
-                        "checkboxes",
-                        "dropdown",
-                        "radios",
-                        "radiosButtons",
-                        "text",
-                        "paragraph",
-                        "file",
-                        "date",
-                        "email",
+                        "title", 
+                        "helpText", 
+                        "fieldset", 
+                        "fieldsetTable", 
+                        "separation", 
+                        "checkbox", 
+                        "checkboxes", 
+                        "dropdown", 
+                        "radios", 
+                        "radiosButtons", 
+                        "text", 
+                        "paragraph", 
+                        "file", 
+                        "date", 
+                        "email", 
                         "number"
-                    ],
+                    ], 
                     "type": "string"
-                },
+                }, 
                 "validations": {
-                    "description": "List of validations of the field",
+                    "description": "List of validations of the field", 
                     "items": {
                         "$ref": "#/definitions/FieldValidation"
-                    },
+                    }, 
                     "type": "array"
                 }
-            },
+            }, 
             "required": [
-                "id",
-                "slug",
-                "label",
-                "type_id",
-                "description",
+                "id", 
+                "slug", 
+                "label", 
+                "type_id", 
+                "description", 
                 "accesses"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "FieldAccess": {
-            "description": "The access is the way to use the field in the context",
+            "description": "The access is the way to use the field in the context", 
             "properties": {
                 "access_id": {
-                    "description": "Access reference",
+                    "description": "Access reference", 
                     "type": "string"
-                },
+                }, 
                 "level": {
-                    "description": "Level of this access for the field",
+                    "description": "Level of this access for the field", 
                     "enum": [
-                        "REQUIRED",
-                        "EDITABLE",
-                        "HIDDEN",
+                        "REQUIRED", 
+                        "EDITABLE", 
+                        "HIDDEN", 
                         "READONLY"
-                    ],
+                    ], 
                     "type": "string"
                 }
-            },
+            }, 
             "required": [
-                "access_id",
+                "access_id", 
                 "level"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "FieldValidation": {
-            "description": "This validation can only be performed on a single field",
+            "description": "This validation can only be performed on a single field", 
             "properties": {
                 "message": {
-                    "description": "Error message if the validation is not verified",
+                    "description": "Error message if the validation is not verified", 
                     "type": "string"
-                },
+                }, 
                 "type": {
-                    "description": "Type of validation (see Validation types table)",
+                    "description": "Type of validation (see Validation types table)", 
                     "enum": [
-                        "EQ",
-                        "GT",
-                        "GTE",
-                        "IS_AGE_ABOVE",
-                        "IS_AGE_UNDER",
-                        "IS_DATE_IN_THE_FUTURE",
-                        "IS_DATE_IN_THE_PAST",
-                        "LT",
-                        "LTE",
-                        "MAXLENGTH",
-                        "MINLENGTH",
-                        "NEQ",
+                        "EQ", 
+                        "GT", 
+                        "GTE", 
+                        "IS_AGE_ABOVE", 
+                        "IS_AGE_UNDER", 
+                        "IS_DATE_IN_THE_FUTURE", 
+                        "IS_DATE_IN_THE_PAST", 
+                        "LT", 
+                        "LTE", 
+                        "MAXLENGTH", 
+                        "MINLENGTH", 
+                        "NEQ", 
                         "REGEXP"
-                    ],
+                    ], 
                     "type": "string"
-                },
+                }, 
                 "value": {
-                    "description": "Value of the validation",
+                    "description": "Value of the validation", 
                     "type": "string"
                 }
-            },
+            }, 
             "required": [
-                "type",
+                "type", 
                 "value"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "Form": {
-            "description": "The central piece of this project",
+            "description": "The central piece of this project", 
             "properties": {
                 "conditions": {
                     "items": {
                         "$ref": "#/definitions/Condition"
-                    },
+                    }, 
                     "type": "array"
-                },
+                }, 
                 "description": {
-                    "description": "Description of the form",
+                    "description": "Description of the form", 
                     "type": "string"
-                },
+                }, 
                 "id": {
-                    "description": "ID of the form",
-                    "readOnly": true,
+                    "description": "ID of the form", 
+                    "readOnly": true, 
                     "type": "integer"
-                },
+                }, 
                 "label": {
-                    "description": "Title of the form",
+                    "description": "Title of the form", 
                     "type": "string"
                 }
-            },
+            }, 
             "required": [
-                "id",
-                "label",
+                "id", 
+                "label", 
                 "description"
-            ],
+            ], 
             "type": "object"
-        },
+        }, 
         "InputError": {
-            "description": "Object that contains field errors as key with a list of string in value",
+            "description": "Object that contains field errors as key with a list of string in value", 
             "properties": {
                 "__all__": {
-                    "description": "Errors on anything except form's fields",
+                    "description": "Errors on anything except form's fields", 
                     "items": {
                         "type": "string"
-                    },
+                    }, 
                     "type": "array"
                 }
-            },
+            }, 
             "type": "object"
-        },
+        }, 
         "InputField": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Field"
                 }
-            ],
+            ], 
             "properties": {
                 "values": {
-                    "description": "Values selected/inputed when the form is in edition mode",
+                    "description": "Values selected/inputed when the form is in edition mode", 
                     "items": {
                         "type": "string"
-                    },
+                    }, 
                     "type": "array"
                 }
             }
-        },
+        }, 
         "InputForm": {
             "allOf": [
                 {
                     "$ref": "#/definitions/Form"
-                },
+                }, 
                 {
                     "properties": {
                         "fields": {
-                            "description": "List of fields ordered in the form",
+                            "description": "List of fields ordered in the form", 
                             "items": {
                                 "$ref": "#/definitions/InputField"
-                            },
+                            }, 
                             "type": "array"
                         }
                     }
                 }
             ]
-        },
+        }, 
         "Item": {
-            "description": "Describe an item in a list",
+            "description": "Describe an item in a list", 
             "properties": {
                 "description": {
-                    "description": "Description of the item",
+                    "description": "Description of the item", 
                     "type": "string"
-                },
+                }, 
                 "label": {
-                    "description": "Label of the item",
+                    "description": "Label of the item", 
                     "type": "string"
-                },
+                }, 
                 "value": {
-                    "description": "Value which defined the item",
+                    "description": "Value which defined the item", 
                     "type": "string"
                 }
-            },
+            }, 
             "required": [
-                "label",
+                "label", 
                 "value"
-            ],
+            ], 
             "type": "object"
         }
-    },
-    "host": "localhost:8000",
+    }, 
+    "host": "localhost:8000", 
     "info": {
-        "description": "django-formidable is a full django application which allows you to create,\nedit, delete and use forms.\n\n##### Field types\n\nList of known types available:\n\n| Type | Description | HTML Component |\n| ---- | ----------- | -------------- |\n| title | Title | h2 |\n| helpText | Helptext | p |\n| fieldset | Group of fields (iterable) | fieldset |\n| fieldsetTable | Group of fields display as table (iterable) | table |\n| separation | Separator line (design only) | hr |\n| checkbox | Checkbox alone | input type=checkbox |\n| checkboxes | Some checkboxes, all checkable | input type=checkbox, all have the same name |\n| dropdown | Dropdown with values | select |\n| radios | Some radios, only one is selected at once | input type=radio |\n| radiosButtons | Some radios display as toggle button | input type=radio |\n| text | Input for one line text | input type=text |\n| paragraph | Input for multiline text | textarea |\n| file | Field to select a local file to be uploaded | input type=file |\n| date | Input for a date (datepicker with it, lang know by application parameter, validation by momentjs) | input type=date |\n| email | Input for an email (validation by regexp) | input |\n| number | Input for a number | input |\n\n##### Validations types\n\nList of validations available by types:\n\n| Field | Validation type |\n| ----- | ----------- |\n| text | MINLENGTH, MAXLENGTH, REGEXP |\n| paragraph | MINLENGTH, MAXLENGTH, REGEXP |\n| date | GT, GTE, LT, LTE, EQ, NEQ, IS_AGE_ABOVE (>=), IS_AGE_UNDER (<), IS_DATE_IN_THE_PAST (< today), IS_DATE_IN_THE_FUTURE (< today) |\n| number | GT, GTE, LT, LTE, EQ, NEQ |\n",
-        "title": "Formidable API",
+        "description": "django-formidable is a full django application which allows you to create,\nedit, delete and use forms.\n\n##### Field types\n\nList of known types available:\n\n| Type | Description | HTML Component |\n| ---- | ----------- | -------------- |\n| title | Title | h2 |\n| helpText | Helptext | p |\n| fieldset | Group of fields (iterable) | fieldset |\n| fieldsetTable | Group of fields display as table (iterable) | table |\n| separation | Separator line (design only) | hr |\n| checkbox | Checkbox alone | input type=checkbox |\n| checkboxes | Some checkboxes, all checkable | input type=checkbox, all have the same name |\n| dropdown | Dropdown with values | select |\n| radios | Some radios, only one is selected at once | input type=radio |\n| radiosButtons | Some radios display as toggle button | input type=radio |\n| text | Input for one line text | input type=text |\n| paragraph | Input for multiline text | textarea |\n| file | Field to select a local file to be uploaded | input type=file |\n| date | Input for a date (datepicker with it, lang know by application parameter, validation by momentjs) | input type=date |\n| email | Input for an email (validation by regexp) | input |\n| number | Input for a number | input |\n\n##### Validations types\n\nList of validations available by types:\n\n| Field | Validation type |\n| ----- | ----------- |\n| text | MINLENGTH, MAXLENGTH, REGEXP |\n| paragraph | MINLENGTH, MAXLENGTH, REGEXP |\n| date | GT, GTE, LT, LTE, EQ, NEQ, IS_AGE_ABOVE (>=), IS_AGE_UNDER (<), IS_DATE_IN_THE_PAST (< today), IS_DATE_IN_THE_FUTURE (< today) |\n| number | GT, GTE, LT, LTE, EQ, NEQ |\n", 
+        "title": "Formidable API", 
         "version": "1.0.0"
-    },
+    }, 
     "paths": {
         "/builder/accesses/": {
             "get": {
-                "description": "List of accesses available.",
+                "description": "List of accesses available.", 
                 "responses": {
                     "200": {
-                        "description": "A list of accesses",
+                        "description": "A list of accesses", 
                         "schema": {
                             "items": {
                                 "$ref": "#/definitions/Access"
-                            },
+                            }, 
                             "type": "array"
                         }
                     }
-                },
+                }, 
                 "summary": "Get accesses"
             }
-        },
+        }, 
         "/builder/forms/": {
             "post": {
-                "description": "Create Form Description",
+                "description": "Create Form Description", 
                 "parameters": [
                     {
-                        "in": "body",
-                        "name": "form",
-                        "required": true,
+                        "in": "body", 
+                        "name": "form", 
+                        "required": true, 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                ],
+                ], 
                 "responses": {
                     "201": {
-                        "description": "Newly created form",
+                        "description": "Newly created form", 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
-                    },
+                    }, 
                     "400": {
-                        "description": "Unexpected error",
+                        "description": "Unexpected error", 
                         "schema": {
                             "$ref": "#/definitions/BuilderError"
                         }
                     }
-                },
+                }, 
                 "summary": "Create a new form"
             }
-        },
+        }, 
         "/builder/forms/{id}/": {
             "get": {
                 "parameters": [
                     {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
+                        "in": "path", 
+                        "name": "id", 
+                        "required": true, 
                         "type": "integer"
                     }
-                ],
+                ], 
                 "responses": {
                     "200": {
-                        "description": "Form",
+                        "description": "Form", 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                },
+                }, 
                 "summary": "Retrieve a Form"
-            },
+            }, 
             "put": {
                 "parameters": [
                     {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
+                        "in": "path", 
+                        "name": "id", 
+                        "required": true, 
                         "type": "integer"
-                    },
+                    }, 
                     {
-                        "in": "body",
-                        "name": "form",
-                        "required": true,
+                        "in": "body", 
+                        "name": "form", 
+                        "required": true, 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                ],
+                ], 
                 "responses": {
                     "200": {
-                        "description": "Form",
+                        "description": "Form", 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
-                    },
+                    }, 
                     "400": {
-                        "description": "Unexpected error",
+                        "description": "Unexpected error", 
                         "schema": {
                             "$ref": "#/definitions/BuilderError"
                         }
                     }
-                },
+                }, 
                 "summary": "Update a Form"
             }
-        },
+        }, 
         "/forms/{id}/": {
             "get": {
                 "parameters": [
                     {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
+                        "in": "path", 
+                        "name": "id", 
+                        "required": true, 
                         "type": "integer"
                     }
-                ],
+                ], 
                 "responses": {
                     "200": {
-                        "description": "A form",
+                        "description": "A form", 
                         "schema": {
                             "$ref": "#/definitions/BuilderForm"
                         }
                     }
-                },
+                }, 
                 "summary": "Get a contextualized form"
             }
-        },
+        }, 
         "/forms/{id}/validate/": {
             "post": {
                 "parameters": [
                     {
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
+                        "in": "path", 
+                        "name": "id", 
+                        "required": true, 
                         "type": "integer"
                     }
-                ],
+                ], 
                 "responses": {
                     "204": {
                         "description": "Validation OK"
-                    },
+                    }, 
                     "400": {
-                        "description": "Validation KO",
+                        "description": "Validation KO", 
                         "schema": {
                             "$ref": "#/definitions/InputError"
                         }
                     }
-                },
+                }, 
                 "summary": "Validate user-data against a form schema."
             }
         }
-    },
+    }, 
     "produces": [
         "application/json"
-    ],
+    ], 
     "schemes": [
         "http"
-    ],
+    ], 
     "swagger": "2.0"
 }

--- a/docs/source/forms.rst
+++ b/docs/source/forms.rst
@@ -200,6 +200,34 @@ Conditions
 
     if only checkbox-1 is checked, field X will be displayed, even if checkbox-2 is unchecked, and vice-versa. If both are checked, fields X and Y will be displayed. If none is checked, fields X and Y will be hidden.
 
+Types for conditional rules
+---------------------------
+At this moment, we can guarantee only the support of the checkboxes and
+dropdown lists, but normally you could use it for any type you want.
+
+Also, you could specify types allowed for the conditions using the settings variable
+``FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES`` By default formidable will accept any type.
+
+.. code-block:: python
+
+    FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES = []  # formidable will allow any type for the conditional rules
+    FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES = ['checkbox']  # formidable will allow checkboxes only
+
+In case you try to configure a conditional display based on a field
+that has been excluded from the allowed types, you'll receive a ``ValidationError``
+when trying to save the form.
+
+Here is a list of all the available types:
+
+.. code-block:: python
+
+    available_types = [
+        'title', 'helpText', 'fieldset', 'fieldsetTable', 'separation',
+        'checkbox', 'checkboxes', 'dropdown', 'radios', 'radiosButtons',
+        'text', 'paragraph', 'file', 'date', 'email', 'number'
+    ]
+
+
 Python builder
 ==============
 

--- a/formidable/forms/conditions.py
+++ b/formidable/forms/conditions.py
@@ -12,13 +12,6 @@ This can be used in the following situations:
   See :class:`formidable.forms.conditions.DisplayIffCondition`
 - Conditional access: change access level (required/editable/...)
 
-.. Note::
-    At this moment, we can guarantee only the support of the checkboxes and
-    dropdown lists, but normally you could use it for any type you want.
-    You could specify types allowed for the conditions using settings variable
-    ``FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES``
-    By default formidable accept all the types.
-
 .. autoclass:: Condition
 
 .. autoclass:: ConditionTest

--- a/formidable/forms/conditions.py
+++ b/formidable/forms/conditions.py
@@ -15,6 +15,9 @@ This can be used in the following situations:
 .. Note::
     At this moment, we can guarantee only the support of the checkboxes and
     dropdown lists, but normally you could use it for any type you want.
+    You could specify types allowed for the conditions using settings variable
+    ``FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES``
+    By default formidable accept all the types.
 
 .. autoclass:: Condition
 

--- a/formidable/forms/conditions.py
+++ b/formidable/forms/conditions.py
@@ -12,6 +12,10 @@ This can be used in the following situations:
   See :class:`formidable.forms.conditions.DisplayIffCondition`
 - Conditional access: change access level (required/editable/...)
 
+.. Note::
+    At this moment, we can guarantee only the support of the checkboxes and
+    dropdown lists, but normally you could use it for any type you want.
+
 .. autoclass:: Condition
 
 .. autoclass:: ConditionTest

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -124,7 +124,7 @@ class FormidableSerializer(WithNestedSerializer):
                     )
                 )
             # check field types are valid
-            if len(condition_fields_allowed_types):
+            if condition_fields_allowed_types:
                 for field_id in condition_fields_ids:
                     field_type = self.get_field_type(data, field_id)
                     if field_type not in condition_fields_allowed_types:

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import copy
 from collections import defaultdict
 
+from django.conf import settings
 from django.db import transaction
 
 from formidable import constants
@@ -84,20 +85,34 @@ class FormidableSerializer(WithNestedSerializer):
         return instance
 
     def _get_fields_slugs(self, data):
-        return [field['slug'] for field in data.get('fields', None)]
+        return [field['slug'] for field in data.get('fields', [])]
+
+    def get_field_type(self, data, field_id):
+        return next(
+            (
+                f['type_id'] for f in data.get('fields', [])
+                if f['slug'] == field_id
+            )
+        )
 
     def check_conditions_cohesion(self, data):
         # 1/ Check references to fields are valid
         fields_slug = self._get_fields_slugs(data)
         targets_action = defaultdict(list)
+
+        condition_fields_allowed_types = getattr(
+            settings, 'FORMIDABLE_CONDITION_FIELDS_ALLOWED_TYPES', []
+        )
         for condition in data['conditions']:
             missing_fields = []
+            condition_fields_ids = []
             for field_id in condition['fields_ids']:
                 targets_action[condition['action']].append(field_id)
                 if field_id not in fields_slug:
                     missing_fields.append(field_id)
             for test in condition['tests']:
                 field_id = test['field_id']
+                condition_fields_ids.append(field_id)
                 if field_id not in fields_slug:
                     missing_fields.append(field_id)
 
@@ -108,23 +123,17 @@ class FormidableSerializer(WithNestedSerializer):
                         ids=', '.join(set(missing_fields))
                     )
                 )
-
-        # # 2/ check there is no more than one rule on a field per action
-        # for action, fields_ids in targets_action.items():
-        #     counter = Counter(fields_ids)
-        #     duplicates = [
-        #         field for field, count in counter.items()
-        #         if count > 1
-        #     ]
-        #     if duplicates:
-        #         raise ValidationError(
-        #             'Action {action} in condition ({name}) is used many times for the same fields ({ids})'.format(  # noqa
-        #                 name=condition['name'],
-        #                 action=action,
-        #                 ids=', '.join(duplicates)
-        #             )
-        #         )
-
+            # check field types are valid
+            if len(condition_fields_allowed_types):
+                for field_id in condition_fields_ids:
+                    field_type = self.get_field_type(data, field_id)
+                    if field_type not in condition_fields_allowed_types:
+                        raise ValidationError(
+                            'Condition ({name}) is using not allowed field type ({type})'.format(  # noqa
+                                name=condition['name'],
+                                type=field_type
+                            )
+                        )
         return data
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Conditional rules are tested and documented for usage with checkboxes. We want to make sure it is possible to use conditional rules based on dropdown lists, by testing and documenting it.

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
