### PR TITLE
Conditional rules contextualization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Trim whitespaces in the generated ``formidable.js`` file. This is more than just cosmetics, it prevents to have a polluted history on this file.
+- Hotfix: Extract conditions and filter them using the fields that exist in the form.
 
 Release 1.4.0 (2018-02-21)
 ==========================

--- a/demo/tests/fixtures/conditions-contextualization.json
+++ b/demo/tests/fixtures/conditions-contextualization.json
@@ -1,0 +1,67 @@
+{
+  "fields": [
+    {
+      "defaults": [],
+      "description": "Yes/No",
+      "disabled": false,
+      "placeholder": null,
+      "required": false,
+      "slug": "to-check",
+      "type_id": "checkbox",
+      "validations": [],
+      "accesses": [
+        { "access_id": "TEST_ROLE", "level": "EDITABLE" },
+        { "access_id": "TEST_ROLE2", "level": "EDITABLE" }
+      ]
+    },
+    {
+      "defaults": [],
+      "description": null,
+      "disabled": false,
+      "label": "second field",
+      "placeholder": null,
+      "required": false,
+      "slug": "to-display",
+      "type_id": "paragraph",
+      "validations": [],
+      "accesses": [
+        { "access_id": "TEST_ROLE2", "level": "EDITABLE" },
+        { "access_id": "TEST_ROLE", "level": "EDITABLE" }
+      ]
+    },
+    {
+      "defaults": [],
+      "description": null,
+      "disabled": false,
+      "label": "Always displayed field",
+      "placeholder": null,
+      "required": false,
+      "slug": "always-displayed",
+      "type_id": "paragraph",
+      "validations": [],
+      "accesses": [
+        { "access_id": "TEST_ROLE2", "level": "EDITABLE" },
+        { "access_id": "TEST_ROLE", "level": "EDITABLE" }
+      ]
+    }
+  ],
+  "id": 1,
+  "label": "Some label here",
+  "description": "Description",
+  "conditions": [
+    {
+      "action": "display_iff",
+      "fields_ids": [
+        "to-display"
+      ],
+      "name": "Rule",
+      "tests": [
+        {
+          "field_id": "to-check",
+          "operator": "eq",
+          "values": [ true ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Strategy

* We're going to pass this hotfix on master, in order to be able to test the changeset using the latest UI lib.
* All the "code" commits will be squashed into one, and we'll leave the "changelog" commit by itself
* The "code" commit will be cherry-picked and applied to the existing tags (1.2.1, 1.3.0, 1.4.0) to backport the changeset to previous stable releases.

## Review

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
