### PR TITLE
Mergeing backport releases into master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ master (unreleased)
 - Trim whitespaces in the generated ``formidable.js`` file. This is more than just cosmetics, it prevents to have a polluted history on this file.
 - Hotfix: Extract conditions and filter them using the fields that exist in the form.
 
+Release 1.4.1 (2018-03-06)
+==========================
+
+- Added Hotfix from #308: Extract conditions and filter them using the fields that exist in the form.
+
 Release 1.4.0 (2018-02-21)
 ==========================
 
@@ -18,6 +23,11 @@ Release 1.4.0 (2018-02-21)
 - Validation endpoint for **user data** doesn't allow GET method anymore (#300).
 - Add support for multiple conditions to target a common field.
 
+Release 1.3.1 (2018-03-06)
+==========================
+
+- Added Hotfix from #308: Extract conditions and filter them using the fields that exist in the form.
+
 Release 1.3.0 (2018-02-14)
 ==========================
 
@@ -26,6 +36,11 @@ Release 1.3.0 (2018-02-14)
 - Allow POST method for form validation endpoint.
 - [Documentation] Fixed a missing ``cd`` in docs. You can't run pytest from project root (#293).
 - includes 7 more languages (not translated yet): Czech, Danish, Finnish, Canadian French, Hungarian, Japanese, Swedish.
+
+Release 1.2.2 (2018-03-06)
+==========================
+
+- Added Hotfix from #308: Extract conditions and filter them using the fields that exist in the form.
 
 Release 1.2.1 (2018-01-12)
 ==========================


### PR DESCRIPTION
In order to have all the Changelog entries in our changelog, and make sure that all the tags are contained in the master branch.