### PR TITLE
Added typing to the demo requirements, added pytest cache to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ demo/var
 *.egg-info
 # Documentation builds
 docs/build/
+docs/.pytest_cache/
 
 # Ignore setup.py-generated directories
 build/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Trim whitespaces in the generated ``formidable.js`` file. This is more than just cosmetics, it prevents to have a polluted history on this file.
 - Hotfix: Extract conditions and filter them using the fields that exist in the form.
+- Added typing to the demo requirements
 
 Release 1.4.1 (2018-03-06)
 ==========================

--- a/demo/requirements-demo.pip
+++ b/demo/requirements-demo.pip
@@ -4,3 +4,5 @@ django-extensions
 freezegun
 django-perf-rec
 mock
+# added a typing module to fix https://github.com/django-extensions/django-extensions/issues/1176
+typing


### PR DESCRIPTION
## Review

This PR fix tests error with the typing for python2. Read more here https://github.com/django-extensions/django-extensions/issues/1176



* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch

