### PR TITLE
Make sure that the `ValidateView.form_valid` method return an actual empty body content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ==================
 
-Nothing here yet.
+- Make sure that the `ValidateView.form_valid` method return an actual empty body content along with a 204 HTTP status response. Before this hotfix, the dictionary passed along as the response content was serialized into a 2-character string to calculate the content-length, but this content was not returned to the client. Some browsers would experience it badly, namely IE11.
 
 Release 1.5.0 (2018-03-09)
 ==========================

--- a/demo/tests/test_integration.py
+++ b/demo/tests/test_integration.py
@@ -415,7 +415,9 @@ class TestValidationEndPoint(FormidableAPITestCase):
             parameters, format='json'
         )
         self.assertEqual(res.status_code, 204)
-        self.assertIn('application/json', str(res.serialize_headers()))
+        self.assertIn(res.content, ("", b""))  # Should be empty
+        # As a consequence, if there's no body content, there shouldn't be any
+        # content-type sent back to the client.
 
     def test_formidable_does_not_exist(self):
         parameters = {

--- a/formidable/views.py
+++ b/formidable/views.py
@@ -267,7 +267,9 @@ class ValidateView(six.with_metaclass(MetaClassView,
         }
 
     def form_valid(self, form):
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+        # Explicitly return a true empty content, to make sure that the
+        # response Content-Length is correctly calculated.
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     def form_invalid(self, form):
         # TODO change response when UI ready


### PR DESCRIPTION
This content is the spec-compatible content to pass along with a 204 HTTP status response.

Before this hotfix, the dictionary passed along as the response content was serialized into a 2-character string to calculate the content-length, but this content was not returned to the client. Some browsers would experience it badly, namely IE11.

## Review

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
