### PR TITLE
Add an encoding to the open file function to support tests on mac os …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Release 1.5.2 (2018-03-30)
 - Allow null and empty condition names.
 - Allow change type for the fields without changing name/slug
 - Added compatibility tests using Django 1.11.
+- Used io.open in tests to avoid locales trouble on OSX
 
 Release 1.5.1 (2018-03-28)
 ==========================

--- a/demo/tests/test_forms.py
+++ b/demo/tests/test_forms.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import json
 import os
+import io
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -778,7 +779,7 @@ class FormidableModelTestCase(TestCase):
         """
         filepath = os.path.join(os.path.dirname(__file__),
                                 '../fixtures/augmentation_heures.json')
-        with open(filepath) as f:
+        with io.open(filepath, 'r', encoding='utf-8') as f:
             schema_definition = json.load(f)
 
         form = Formidable.from_json(schema_definition)


### PR DESCRIPTION
## Review

This PR fix problem with the encoding when you run tests on mac. 

* [x] Tests<!-- mandatory -->
* [ ] Delete your branch
