### PR TITLE
v1.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,16 +2,16 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 1.6.0 (2018-04-06)
+==========================
 
 - Added compatibility with Python 3.6 (#318).
+- Allow change type for the fields without changing name/slug
 
 Release 1.5.2 (2018-03-30)
 ==========================
 
 - Allow null and empty condition names.
-- Allow change type for the fields without changing name/slug
 - Added compatibility tests using Django 1.11.
 
 Release 1.5.1 (2018-03-28)

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.6.0.dev0'
+version = '1.6.0'
 json_version = latest_version


### PR DESCRIPTION
note: the latest PR has mangled the 1.5.2 changelog. it's fixed here

## Release

* [x] Fetch translations from Crowdin -- no change
* [x] Change VERSION with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [ ] Tag the resulting commit with the appropriate tag
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
