### PR TITLE
Add a deprecation warning for django 1.8 and 1.9

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,10 @@ ChangeLog
 master (unreleased)
 ===================
 
+**Deprecation Warning**: Support for django<=1.9 will be dropped by the version 2.0.0.
+
 - Added a tool to build the JSON Schema from the ``formidable.yml`` file, and include it into the documentation.
+- Add a deprecation warning for django 1.8 and 1.9
 
 Release 1.6.0 (2018-04-06)
 ==========================

--- a/formidable/app.py
+++ b/formidable/app.py
@@ -6,6 +6,10 @@ The :class:`FormidableConfig` checks various configuration settings:
 * post-update and post-create callbacks
 """
 
+import warnings
+from distutils.version import StrictVersion
+
+import django
 from django.apps import AppConfig
 
 
@@ -21,3 +25,9 @@ class FormidableConfig(AppConfig):
         """
         from .views import check_callback_configuration
         check_callback_configuration()
+
+        # Deprecation warning for django 1.8 and 1.9
+        if StrictVersion(django.get_version()) < StrictVersion("1.10"):
+            warnings.warn("Support for Django 1.8 and 1.9 is about to be "
+                          "dropped. Please update to a newer version.",
+                          DeprecationWarning)


### PR DESCRIPTION
## Review

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch