### PR TITLE
v1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+master (unreleased)
+===================
+
+Nothing here yet.
+
 Release 1.7.0 (2018-04-20)
 ==========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 1.7.0 (2018-04-20)
+==========================
 
 **Deprecation Warning**: Support for django<=1.9 will be dropped by the version 2.0.0.
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,6 +2,11 @@
 Deprecation timeline
 ====================
 
+Next deprecations
+=================
+
+The 1.7.0 version will be the last one to support Django 1.8 & 1.9.
+
 From 1.3.0 to 1.4.0
 ===================
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.7.0.dev0'
+version = '1.7.0'
 json_version = latest_version

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '1.7.0'
+version = '2.0.0.dev0'
 json_version = latest_version


### PR DESCRIPTION
Changelog:

**Deprecation Warning**: Support for django<=1.9 will be dropped by the version 2.0.0.

- Added a tool to build the JSON Schema from the ``formidable.yml`` file, and include it into the documentation.
- Add a deprecation warning for django 1.8 and 1.9


## Release

* [x] ~~Fetch translations from Crowdin~~ still broken...
* [x] Change VERSION with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [ ] Tag the resulting commit with the appropriate tag
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
