### PR TITLE
Added the JSON ``version`` when going through the ``Formidable.to_json()`` class method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Release 2.0.0 (2018-05-30)
 
 - Deprecate support for Django 1.8 and Django 1.9 (#325).
 - Drop crowdin for translation handling (#333).
+- Added the JSON ``version`` when going through the ``Formidable.to_json()`` class method. This would ensure that stored schemas would carry their version and wouldn't need extra JSON schema migrations (#337).
 
 Release 1.7.0 (2018-04-20)
 ==========================

--- a/demo/tests/test_form_from_schema.py
+++ b/demo/tests/test_form_from_schema.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django import forms
 from freezegun import freeze_time
 
+from formidable import json_version
 from formidable.constants import REQUIRED
 from formidable.forms import (
     FormidableForm, fields, get_dynamic_form_class_from_schema
@@ -24,6 +25,15 @@ class TestFormFromSchema(TestCase):
         return ContextFormSerializer(instance=formidable, context={
             'role': role
         }).data
+
+    def test_version(self):
+        class TestCharField(FormidableForm):
+            """ Test charfield """
+            charfield = fields.CharField()
+        formidable = TestCharField.to_formidable(label='label')
+        schema = self.get_schema(formidable, 'jedi')
+        self.assertIn('version', schema)
+        self.assertEqual(schema['version'], json_version)
 
     def test_charfield(self):
         class TestCharField(FormidableForm):

--- a/formidable/models.py
+++ b/formidable/models.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from formidable import constants
+from formidable import constants, json_version
 from formidable.register import FieldSerializerRegister
 from jsonfield.fields import JSONField
 
@@ -63,7 +63,9 @@ class Formidable(models.Model):
 
     def to_json(self):
         from formidable.serializers import FormidableSerializer
-        return FormidableSerializer(self).data
+        json_data = FormidableSerializer(self).data
+        json_data['version'] = json_version
+        return json_data
 
     def __str__(self):
         return '{formidable.label}'.format(formidable=self)

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from django.conf import settings
 from django.db import transaction
 
-from formidable import constants
+from formidable import constants, json_version
 from formidable.forms import conditions
 from formidable.models import Formidable
 from formidable.serializers import fields
@@ -161,6 +161,11 @@ class ContextFormSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super(ContextFormSerializer, self).__init__(*args, **kwargs)
         self.fields['fields'].set_context('role', self._context['role'])
+
+    def to_representation(self, obj):
+        data = super(ContextFormSerializer, self).to_representation(obj)
+        data['version'] = json_version
+        return data
 
 
 def get_access(accesses, role):


### PR DESCRIPTION
This would ensure that stored schemas would carry their version and wouldn't need extra JSON schema migrations.

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
