### PR TITLE
Moved the injection of the JSON ``version`` into the serializer, rather than the ``Formidable.to_json()`` class method.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- Moved the injection of the JSON ``version`` into the serializer, rather than the ``Formidable.to_json()`` class method. The serializer is called by the method, so it's idempotent.
 
 Release 2.1.0 (2018-06-21)
 ==========================

--- a/formidable/models.py
+++ b/formidable/models.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-from formidable import constants, json_version
+from formidable import constants
 from formidable.register import FieldSerializerRegister
 from jsonfield.fields import JSONField
 
@@ -64,7 +64,6 @@ class Formidable(models.Model):
     def to_json(self):
         from formidable.serializers import FormidableSerializer
         json_data = FormidableSerializer(self).data
-        json_data['version'] = json_version
         return json_data
 
     def __str__(self):

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -147,6 +147,11 @@ class FormidableSerializer(WithNestedSerializer):
         with transaction.atomic():
             return super(FormidableSerializer, self).save(*args, **kwargs)
 
+    def to_representation(self, obj):
+        data = super(FormidableSerializer, self).to_representation(obj)
+        data['version'] = json_version
+        return data
+
 
 class ContextFormSerializer(serializers.ModelSerializer):
 


### PR DESCRIPTION

The serializer is called by the method, so it's idempotent.

## Review

* [x] Tests - tests are unchanged
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
