### PR TITLE
Optimize the CircleCI build by using less workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,49 +1,18 @@
 version: 2
 jobs:
-  # Setup Python 2.7
-  setup27:
-    working_directory: ~/django-formidable
+  build:
     docker:
-      - image: circleci/python:2.7
+      - image: themattrix/tox
+    working_directory: ~/django-formidable
     steps:
       - checkout
       - run:
-          command: |
-            pip install --user -e ./
-  # Setup Python 3.6
-  setup36:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
+          name: Install dependencies
+          command: pip install --user tox
       - run:
-          command: |
-            pip install --user -e ./
-  # Setup Python 3.5
-  setup35:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:3.5
-    steps:
-      - checkout
-      - run:
-          command: |
-            pip install --user -e ./
+          name: Run the test suite
+          command: tox -r
 
-  # Linters
-  lint:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: Run linters (flake8 + isort)
-          command: |
-            pip install --user tox
-            ~/.local/bin/tox -e flake8,isort-check
-  # Docs job
   docs:
     working_directory: ~/django-formidable
     docker:
@@ -56,68 +25,16 @@ jobs:
             python --version
             sudo apt update && sudo apt install python-pip python-dev
       - run:
-          name: Run Django doc tests using tox
+          name: Run Sphinx doc tests using tox
           command: |
             pip install --user tox
             ~/.local/bin/tox -e docs
-
-  djangopy27:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:2.7
-    steps:
-      - checkout
-      - run:
-          name: Run Django tests using Python 2.7
-          command: |
-            pip install --user tox
-            ~/.local/bin/tox -e $(~/.local/bin/tox -l | grep py27 | tr '\n' ',')
-
-  djangopy36:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: Run Django tests using Python 3.6
-          command: |
-            pip install --user tox
-            ~/.local/bin/tox -e $(~/.local/bin/tox -l | grep py36 | tr '\n' ',')
-
-  djangopy35:
-    working_directory: ~/django-formidable
-    docker:
-      - image: circleci/python:3.5
-    steps:
-      - checkout
-      - run:
-          name: Run Django tests using Python 3.5
-          command: |
-            pip install --user tox
-            ~/.local/bin/tox -e $(~/.local/bin/tox -l | grep py35 | tr '\n' ',')
 
 workflows:
   version: 2
   tests:
     jobs:
-      # Run setup jobs
-      - setup27
-      - setup35
-      - setup36
-      # Run linters
-      - lint
-      # Run docs job (using 2.7, but whatever)
+      # Run Python / Django tests
+      - build
+      # Build docs (requires npm/node)
       - docs
-      # Running tests related to Python 2.7
-      - djangopy27:
-          requires:
-            - setup27
-      # Running tests related to Python 3.6
-      - djangopy36:
-          requires:
-            - setup36
-      # Running tests related to Python 3.5 (soon to be deprecated)
-      - djangopy35:
-          requires:
-            - setup35

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ ChangeLog
 master (unreleased)
 ===================
 
-- Upgrade to Circle-CI 2 (before the end of life of Circle-CI v1 on August, 31st 2018).
+- Upgrade to Circle-CI 2 (before the end of life of Circle-CI v1 on August, 31st 2018). (#342)
+- Optimize Circle-CI usage by using the tox matrix in tests (#343)
 
 Release 2.1.1 (2018-06-22)
 ==========================


### PR DESCRIPTION
PeopleDoc has a limited number of workers, using this Docker Image allows us to spare resources.

## Review

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
