### PR TITLE
CircleCI optimization: do not install tox, it's already there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies
-          command: pip install --user tox
-      - run:
           name: Run the test suite
           command: tox -r
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ master (unreleased)
 - Upgrade to Circle-CI 2 (before the end of life of Circle-CI v1 on August, 31st 2018). (#342)
 - Optimize Circle-CI usage by using the tox matrix in tests (#343)
 - Change the global exception handling error level, from "error" to "exception". It'll provide better insights if you're using Logmatic or any other logging aggregator (#336).
+- Skip `tox` installation in the circle-ci environment: it's already there (#344).
 
 Release 2.1.1 (2018-06-22)
 ==========================


### PR DESCRIPTION

And still, this `--user` install isn't used because the tox package installed by the docker image is the first in the `$PATH`.

## Review

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
