### PR TITLE
fields parameters are not the write-only anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ master (unreleased)
 - Change the global exception handling error level, from "error" to "exception". It'll provide better insights if you're using Logmatic or any other logging aggregator (#336).
 - Skip `tox` installation in the circle-ci environment: it's already there (#344).
 - Refactoring of the field builder (Use only one module for the form builder factory) (#347).
+- Add `parameters` to the fields schema
 
 Release 2.1.2 (2018-08-29)
 ==========================

--- a/demo/requirements-demo.pip
+++ b/demo/requirements-demo.pip
@@ -6,3 +6,5 @@ django-perf-rec
 mock
 # added a typing module to fix https://github.com/django-extensions/django-extensions/issues/1176
 typing
+# A temporary workaround for DRF-related error:
+Markdown~=2.6

--- a/demo/tests/serializers/test_formidable_serializer.py
+++ b/demo/tests/serializers/test_formidable_serializer.py
@@ -78,7 +78,7 @@ class TestCustomFieldSerializer(TestCase):
         # test serialized data
         self.assertIn('meta_info', data)
         self.assertIn('some_another_data', data)
-        self.assertNotIn('parameters', data)
+        self.assertIn('parameters', data)
         # remove instance
         self.instance.delete()
 

--- a/formidable/serializers/fields.py
+++ b/formidable/serializers/fields.py
@@ -114,7 +114,7 @@ class FieldSerializer(WithNestedSerializer):
     # redefine here the order field just to take it at the save/update time
     # The order is automatically calculated, if the order is define in
     # incoming payload, it will be automatically overridden.
-    parameters = serializers.JSONField(write_only=True)
+    parameters = serializers.JSONField()
     order = serializers.IntegerField(write_only=True, required=False)
     defaults = DefaultSerializer(many=True, required=False)
     description = serializers.CharField(required=False, allow_null=True,
@@ -126,7 +126,9 @@ class FieldSerializer(WithNestedSerializer):
         if 'help_text' in data:
             data['description'] = data.pop('help_text')
 
-        data['parameters'] = {}
+        if not data.get('parameters'):
+            data['parameters'] = {}
+
         for config_field in self.get_config_fields():
             data['parameters'][config_field] = data.pop(config_field, None)
 
@@ -137,7 +139,6 @@ class FieldSerializer(WithNestedSerializer):
         for config_field in self.get_config_fields():
             if instance.parameters is not None:
                 field[config_field] = instance.parameters.get(config_field)
-        field.pop('parameters', None)
         return field
 
     def get_config_fields(self):


### PR DESCRIPTION
## Review

This PR closes FORM-778

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
  * [ ] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [ ] Migration(s)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch

<!-- THE FOLLOWING IS ONLY FOR A RELEASE PULL-REQUEST -->
<!-- uncomment the block to make it real

## Release





* [ ] Change `formidable.version` with the appropriate tag
* [ ] Amend `CHANGELOG.rst` (check the release date)
* [ ] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [ ] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [ ] Tag the appropiate commit with the appropriate tag (i.e. not the "back to dev one")
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI

-->
