### PR TITLE
Documentation build is KO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   docs:
     working_directory: ~/django-formidable
     docker:
-      - image: circleci/node:4.8.2
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ ChangeLog
 
 master (unreleased)
 ===================
-Nothing here yet.
+
+- Fix documentation build (#363).
 
 Release 3.0.1 (2019-03-01)
 ==========================


### PR DESCRIPTION
Circle-CI images fails to build.

ref: https://circleci.com/gh/peopledoc/django-formidable/1607

We need a node image able to install Python, or the other way around.