### PR TITLE
Upgrading dependency to Django REST Framework up to 3.9.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Fix documentation build (#363).
+- Upgrade requirements to Django REST Framework 3.9.x.
 
 Release 3.0.1 (2019-03-01)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Warnings
 
 * Python Compatibility : Python 2.7, 3.5, 3.6
 * Django compatibility : Django 1.10, 1.11
-* Django REST Framework : Compatible from the version 3.5.4 to 3.8.x ; **django-formidable is incompatible with the 3.9.x series**.
+* Django REST Framework : Compatible from the version 3.5.4 to 3.9.x.
 
 See the `Deprecation timeline <http://django-formidable.readthedocs.io/en/latest/deprecations.html>`_ document for more information on deprecated versions.
 

--- a/demo/tests/fixtures/form-data.json
+++ b/demo/tests/fixtures/form-data.json
@@ -8,7 +8,6 @@
       "description": "title",
       "accesses": []
     },
-
     {
       "id": "name",
       "slug": "name",
@@ -52,7 +51,9 @@
       "label": "text1",
       "type_id": "text",
       "description": "text",
-      "accesses": []
+      "accesses": [
+          {"access_id": "jedi", "level": "REQUIRED"}
+      ]
     }
   ],
   "description": "Test description",

--- a/demo/tests/perfs/test_perfs_rec.perf.yml
+++ b/demo/tests/perfs/test_perfs_rec.perf.yml
@@ -10,22 +10,76 @@ create-form:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: SAVEPOINT `#`
 - db: INSERT INTO "formidable_formidable" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
 - db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
 get-context-form:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND NOT ("formidable_access"."level" = #) AND "formidable_access"."field_id" IN (...))'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
 retrieve-form:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
 update-form-with-changes:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: SAVEPOINT `#`
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE ("formidable_field"."form_id" = # AND "formidable_field"."slug" IN (...))'
+- db: DELETE FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: DELETE FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...)
+- db: DELETE FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: DELETE FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: DELETE FROM "formidable_field" WHERE "formidable_field"."id" IN (...)
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: INSERT INTO "formidable_field" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
@@ -33,12 +87,14 @@ update-form-with-changes:
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
@@ -52,42 +108,54 @@ update-form-without-changes:
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_field" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
@@ -98,3 +166,7 @@ validate-form:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: 'SELECT ... FROM "formidable_access" WHERE ("formidable_access"."access_id" = # AND "formidable_access"."field_id" IN (...))'
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)

--- a/demo/tests/test_integration.py
+++ b/demo/tests/test_integration.py
@@ -171,7 +171,7 @@ class UpdateFormTestCase(FormidableAPITestCase):
             'description': 'edited description',
             'fields': []
         }
-        res = self.client.put(self.edit_url, data)
+        res = self.client.put(self.edit_url, data, format="json")
         self.assertEquals(res.status_code, 200)
         formidable = Formidable.objects.order_by('pk').last()
         self.assertEquals(formidable.pk, self.form.pk)
@@ -188,7 +188,7 @@ class UpdateFormTestCase(FormidableAPITestCase):
         url = self.edit_url
         self.assertFalse(url.endswith('/'))
         res = self.client.put(
-            url, data
+            url, data, format="json"
         )
         self.assertEquals(res.status_code, 200)
         res = self.client.put(
@@ -209,7 +209,7 @@ class UpdateFormTestCase(FormidableAPITestCase):
         )
         self.assertEquals(res.status_code, 200)
         res = self.client.get(
-            url + '/', form_data, format='json'
+            url + '/', form_data
         )
         self.assertEquals(res.status_code, 200)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                  'guillaume.gerard@people-doc.com',
     install_requires=[
         'Django',
-        'djangorestframework<3.9',
+        'djangorestframework<4.0.0',
         'markdown',
         'python-dateutil',
         'jsonfield',


### PR DESCRIPTION
## Why this patch

Originating this PR: a moderate security alert on Django REST Framework. Although we don't use the incriminated feature, we _had_ to upgrade our supported version.

## Impacts on tests

The patch wasn't supposed to impact tests, because there's no apparent regression on our runtime codebase. Although, it raised an issue in our "Perf Rec" tests, that were trying to create forms with the wrong TestClient.

The consequence of this mishandling of the "POST" method was that the Formidable object was created, but none of its "children" (fields, accesses, validations, conditions, etc).

Switching to the DRF APITestClient and passing the `format='json'` argument led to fix the form creation. As a consequence, the SQL queries executed now reflect the creation of the objects in the Database *and* their retrieval afterwards.

Please note that the `.yml` files diff are a bit confusing, because git can't figure out which lines belong to which tests. You may want to inspect the *result* files instead of the diff to ensure that now we're actually creating complete forms in our tests using the HTTP API.

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments (README)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
