### PR TITLE
Extend the test matrix to spread through different DRF versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- Extend the test matrix to spread through different DRF versions.
 
 Release 3.1.0 (2019-06-03)
 ==========================

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    django110-py{27,35,36}
-    django111-py{27,35,36}
+    django110-py{27,35,36}-drf{38,39,310}
+    django111-py{27,35,36}-drf{38,39,310}
     spectest
     flake8
     isort-check
@@ -15,8 +15,13 @@ deps =
     ; Django versions
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    ; Python versions
     py27: django-perf-rec>=3,<4
     py{35,36}: django-perf-rec
+    ; DRF versions
+    drf38: djangorestframework<3.9
+    drf39: djangorestframework<3.10
+    drf310: djangorestframework<3.11
     ; Requirements from demo project
     -rdemo/requirements-demo.pip
 commands =


### PR DESCRIPTION
## Review

My goal here is to prove that Django-Formidable works with any version of DRF between 3.8 and 3.9, up to the current 3.9.x

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
