### PR TITLE
Drop support for Django 1.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Extend the test matrix to spread through different DRF versions.
+- Drop support for Django 1.10 (EOL was in December 2nd, 2017).
 
 Release 3.1.0 (2019-06-03)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -14,14 +14,11 @@ Warnings
 ========
 
 * Python Compatibility : Python 2.7, 3.5, 3.6
-* Django compatibility : Django 1.10, 1.11
-* Django REST Framework : Compatible from the version 3.5.4 to 3.9.x.
+* Django compatibility : Django 1.11 (support of Django 2 is coming soon).
+* Django REST Framework : Compatible from the version 3.8.x to 3.10.x
 
 See the `Deprecation timeline <http://django-formidable.readthedocs.io/en/latest/deprecations.html>`_ document for more information on deprecated versions.
 
-.. warning::
-
-   As of its 3.7 version, it appears that Django REST Framework only supports Django 1.10 & 1.11. Carefully freeze your dependencies if your Django version is not compatible.
 
 License
 =======

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,6 +2,13 @@
 Deprecation timeline
 ====================
 
+From 3.1.0 to ...
+=================
+
+October/November 2019
+
+* Drop support for Django 1.10 (EOL was in December 2nd, 2017)
+
 From 3.0.1 to 3.1.0
 ===================
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    django110-py{27,35,36}-drf{38,39,310}
     django111-py{27,35,36}-drf{38,39,310}
     spectest
     flake8
@@ -13,7 +12,6 @@ usedevelop = True
 changedir = demo
 deps =
     ; Django versions
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     ; Python versions
     py27: django-perf-rec>=3,<4


### PR DESCRIPTION
EOL was in December 2nd, 2017.

* Added deprecation mention in the docs,
* Changed a few obsolete items in the readme.

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
