### PR TITLE
Add ``select_for_update()`` on selection when the Form is modified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ master (unreleased)
 - Extend the test matrix to spread through different DRF versions.
 - Drop support for Django 1.10 (EOL was in December 2nd, 2017).
 - Launch tests on Postgresql as well as SQLite. Launching these tests will be possible both locally and on Circle-CI. See the "dev" documentation on how you can run tests on your development environment (#161).
+- Add ``select_for_update()`` on selection in querysets when the Form is about to be modified (namely ``PUT`` & ``PATCH`` views). This could prevent Database deadlocks when several changes are attempted on the same **large** form.
 
 Release 3.1.0 (2019-06-03)
 ==========================

--- a/demo/tests/perfs/test_perfs_rec.perf.yml
+++ b/demo/tests/perfs/test_perfs_rec.perf.yml
@@ -9,7 +9,6 @@ TestPerfRec.create-form:
 - db: 'UPDATE "django_session" SET ... WHERE "django_session"."session_key" = #'
 - db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
-- db: SAVEPOINT `#`
 - db: INSERT INTO "formidable_formidable" (...) VALUES (...)
 - db: INSERT INTO "formidable_field" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
@@ -47,7 +46,6 @@ TestPerfRec.create-form:
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
 - db: INSERT INTO "formidable_access" (...) VALUES (...)
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
@@ -62,7 +60,6 @@ TestPerfRec.create-form-pg:
 - db: 'UPDATE "django_session" SET ... WHERE "django_session"."session_key" = #'
 - db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > #::timestamptz AND "django_session"."session_key" = #)'
-- db: SAVEPOINT `#`
 - db: INSERT INTO "formidable_formidable" (...) VALUES (...) RETURNING "formidable_formidable"."id"
 - db: INSERT INTO "formidable_field" (...) VALUES (...) RETURNING "formidable_field"."id"
 - db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
@@ -100,7 +97,6 @@ TestPerfRec.create-form-pg:
 - db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
 - db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
 - db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
@@ -140,8 +136,8 @@ TestPerfRec.retrieve-form-pg:
 - db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
 TestPerfRec.update-form-with-changes:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
-- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE ("formidable_field"."form_id" = # AND "formidable_field"."slug" IN (...))'
@@ -165,16 +161,49 @@ TestPerfRec.update-form-with-changes:
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
-TestPerfRec.update-form-with-changes-pg:
-- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > #::timestamptz AND "django_session"."session_key" = #)'
-- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
+- db: RELEASE SAVEPOINT `#`
+TestPerfRec.update-form-with-changes-patch:
+- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
+- db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
+- db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE ("formidable_field"."form_id" = # AND "formidable_field"."slug" IN (...))'
+- db: DELETE FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: DELETE FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...)
+- db: DELETE FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: DELETE FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: DELETE FROM "formidable_field" WHERE "formidable_field"."id" IN (...)
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: INSERT INTO "formidable_field" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: INSERT INTO "formidable_access" (...) VALUES (...)
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: RELEASE SAVEPOINT `#`
+TestPerfRec.update-form-with-changes-patch-pg:
+- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > #::timestamptz AND "django_session"."session_key" = #)'
+- db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = # FOR UPDATE NOWAIT'
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE ("formidable_field"."form_id" = # AND "formidable_field"."slug" IN (...))'
@@ -198,16 +227,49 @@ TestPerfRec.update-form-with-changes-pg:
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: RELEASE SAVEPOINT `#`
+TestPerfRec.update-form-with-changes-pg:
+- db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > #::timestamptz AND "django_session"."session_key" = #)'
+- db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = # FOR UPDATE NOWAIT'
+- db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
+- db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE ("formidable_field"."form_id" = # AND "formidable_field"."slug" IN (...))'
+- db: DELETE FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: DELETE FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...)
+- db: DELETE FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: DELETE FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: DELETE FROM "formidable_field" WHERE "formidable_field"."id" IN (...)
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
+- db: INSERT INTO "formidable_field" (...) VALUES (...) RETURNING "formidable_field"."id"
+- db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
+- db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
+- db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
+- db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
+- db: INSERT INTO "formidable_access" (...) VALUES (...) RETURNING "formidable_access"."id"
+- db: 'UPDATE "formidable_field" SET ... WHERE "formidable_field"."id" = #'
+- db: 'SELECT "formidable_access"."access_id" FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
+- db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
+- db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
+- db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
+- db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: RELEASE SAVEPOINT `#`
 TestPerfRec.update-form-without-changes:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
-- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
@@ -259,16 +321,16 @@ TestPerfRec.update-form-without-changes:
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: RELEASE SAVEPOINT `#`
 TestPerfRec.update-form-without-changes-pg:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > #::timestamptz AND "django_session"."session_key" = #)'
-- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'
 - db: SAVEPOINT `#`
+- db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = # FOR UPDATE NOWAIT'
 - db: 'UPDATE "formidable_formidable" SET ... WHERE "formidable_formidable"."id" = #'
 - db: 'SELECT "formidable_field"."slug" FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = #'
@@ -320,12 +382,12 @@ TestPerfRec.update-form-without-changes-pg:
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
 - db: 'UPDATE "formidable_access" SET ... WHERE "formidable_access"."id" = #'
-- db: RELEASE SAVEPOINT `#`
 - db: 'SELECT ... FROM "formidable_field" WHERE "formidable_field"."form_id" = # ORDER BY "formidable_field"."order" ASC'
 - db: SELECT ... FROM "formidable_item" WHERE "formidable_item"."field_id" IN (...) ORDER BY "formidable_item"."order" ASC
 - db: SELECT ... FROM "formidable_default" WHERE "formidable_default"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_validation" WHERE "formidable_validation"."field_id" IN (...)
 - db: SELECT ... FROM "formidable_access" WHERE "formidable_access"."field_id" IN (...)
+- db: RELEASE SAVEPOINT `#`
 TestPerfRec.validate-form:
 - db: 'SELECT ... FROM "django_session" WHERE ("django_session"."expire_date" > # AND "django_session"."session_key" = #)'
 - db: 'SELECT ... FROM "formidable_formidable" WHERE "formidable_formidable"."id" = #'

--- a/formidable/serializers/forms.py
+++ b/formidable/serializers/forms.py
@@ -144,8 +144,12 @@ class FormidableSerializer(WithNestedSerializer):
         return data
 
     def save(self, *args, **kwargs):
-        with transaction.atomic():
-            return super(FormidableSerializer, self).save(*args, **kwargs)
+        # Wrap around a transaction only if we're not already in a transaction.
+        connection = transaction.get_connection()
+        if not connection.in_atomic_block:
+            with transaction.atomic():
+                return super(FormidableSerializer, self).save(*args, **kwargs)
+        return super(FormidableSerializer, self).save(*args, **kwargs)
 
     def to_representation(self, obj):
         data = super(FormidableSerializer, self).to_representation(obj)


### PR DESCRIPTION
The main use-case is ``PUT`` and ``PATCH`` views.

This could prevent Database deadlocks when several changes are attempted on the same **large** form.

The only place where ``select_for_update()`` is used is on the save() of the Form. It should prevent further calls to the API to request the change because, as far as I can say, here is what happens:

1. the transaction is started,
2. the "for update" lock is requested on the form record,
3. the other operations (update/delete/create of "children") happen,
4. the transaction is committed and thus, the lock is released.

As soon as step 2 is launched, any other session that would want to lock the record fail and a `DatabaseError` would be raised. And as we don't have any endpoint in the API that allow modifications of children records, this lock should be freed after the full update.

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
