### PR TITLE
Added support for Django 2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- Add support to Django 2.2 (#326).
 
 Release 3.2.0 (2019-11-07)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ edit, delete and use forms.
 Warnings
 ========
 
-* Python Compatibility : Python 2.7, 3.5, 3.6
-* Django compatibility : Django 1.11 (support of Django 2 is coming soon).
+* Python Compatibility : Python 2.7 (for Django 1.11 only), 3.5, 3.6
+* Django compatibility : Django 1.11, 2.2.
 * Django REST Framework : Compatible from the version 3.8.x to 3.10.x
 
 See the `Deprecation timeline <http://django-formidable.readthedocs.io/en/latest/deprecations.html>`_ document for more information on deprecated versions.

--- a/demo/demo/builder/views.py
+++ b/demo/demo/builder/views.py
@@ -2,8 +2,9 @@
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView
+from django.urls import reverse
+
 from formidable.models import Formidable
-from django.core.urlresolvers import reverse
 from formidable.accesses import get_accesses
 
 

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -44,17 +44,16 @@ INSTALLED_APPS = (
     'demo.builder',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'demo.urls'
 

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -1,14 +1,27 @@
+from distutils.version import StrictVersion as version
+import django
 from django.conf.urls import include, url
 from django.contrib import admin
 
 from demo.views import FormPreview, DemoValidateViewFromSchema
 
 urlpatterns = [
-    url(r'^api/', include('formidable.urls', namespace='formidable')),
+    url(r'^api/',
+        include(('formidable.urls', 'formidable'), namespace='formidable')),
     url(r'^api/forms/(?P<pk>\d+)/validate_schema/?$',
         DemoValidateViewFromSchema.as_view(),
         name='form_validation_schema'),
-    url(r'^admin/', include(admin.site.urls)),
     url(r'^preview/(?P<pk>\d+)/', FormPreview.as_view()),
-    url(r'^forms/', include('demo.builder.urls', namespace='builder')),
+    url(r'^forms/',
+        include(('demo.builder.urls', 'builder'), namespace='builder')),
 ]
+
+if version(django.get_version()) < version("2.0"):
+    urlpatterns += [
+        url(r'^admin/', include(admin.site.urls)),
+    ]
+else:
+    from django.urls import path  # noqa
+    urlpatterns += [
+        path(r'admin/', admin.site.urls, 'admin'),
+    ]

--- a/demo/tests/test_exception_handler.py
+++ b/demo/tests/test_exception_handler.py
@@ -4,7 +4,7 @@ Tests for the exception handling module, common with every view in Formidable.
 """
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import PermissionDenied
 from django import forms
 from django.http import Http404

--- a/demo/tests/test_fields.py
+++ b/demo/tests/test_fields.py
@@ -9,15 +9,15 @@ from formidable.forms import BaseDynamicForm, fields
 
 class RenderingFormatField(TestCase):
 
-    class TestForm(BaseDynamicForm):
-
+    class MockForm(BaseDynamicForm):
+        """Mock Form"""
         title = fields.TitleField(label='Onboarding Form')
         helptext = fields.HelpTextField(text='Enter your **address**')
         sepa = fields.SeparatorField()
 
     def setUp(self):
         super(RenderingFormatField, self).setUp()
-        self.form = self.TestForm()
+        self.form = self.MockForm()
 
     def test_render_help_text(self):
         text = self.form.as_p()

--- a/demo/tests/test_integration.py
+++ b/demo/tests/test_integration.py
@@ -7,9 +7,9 @@ import json
 
 from copy import deepcopy
 
-from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.db import DatabaseError
+from django.urls import reverse
 import django_perf_rec
 
 from freezegun import freeze_time

--- a/demo/tests/test_perfs_rec.py
+++ b/demo/tests/test_perfs_rec.py
@@ -2,11 +2,7 @@
 import os
 import json
 
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
-
+from django.urls import reverse
 from django.conf import settings
 from django_perf_rec import TestCaseMixin
 from rest_framework.test import APITestCase

--- a/demo/tests/test_post_save_callbacks.py
+++ b/demo/tests/test_post_save_callbacks.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from copy import deepcopy
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.test import TestCase, override_settings
 

--- a/demo/tests/test_post_save_callbacks_regression_tests.py
+++ b/demo/tests/test_post_save_callbacks_regression_tests.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from copy import deepcopy
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 from django.conf import settings
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,6 +2,14 @@
 Deprecation timeline
 ====================
 
+From 3.2.0 to... ?
+==================
+
+.. versionadded:: X.Y.Z
+
+    Added support for Django 2.2. Django Formidable should probably work on Django 2.0 and 2.1, but it's not in our test suite. We've decided to skip those versions because of their short-term support.
+
+
 From 3.1.0 to 3.2.0
 ===================
 

--- a/formidable/forms/widgets.py
+++ b/formidable/forms/widgets.py
@@ -157,7 +157,7 @@ class HelpTextWidget(FormidableWidget):
     type_id = 'help_text'
     input_type = 'help_text'
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, **kwargs):
         return markdown(value)
 
 
@@ -170,7 +170,7 @@ class TitleWidget(FormidableWidget):
         self.tag = tag
         super(TitleWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, **kwargs):
         tag = attrs.get('tag', None) or self.tag
         return '<{tag}>{value}</{tag}>'.format(
             tag=tag, value=value
@@ -182,5 +182,5 @@ class SeparatorWidget(FormidableWidget):
     type_id = 'separator'
     input_type = 'separator'
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, **kwargs):
         return '<hr>'

--- a/formidable/migrations/0001_initial.py
+++ b/formidable/migrations/0001_initial.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
                 ('label', models.CharField(max_length=256)),
                 ('order', models.IntegerField()),
                 ('help_text', models.TextField(null=True, blank=True)),
-                ('field', models.ForeignKey(related_name='items', to='formidable.Field')),
+                ('field', models.ForeignKey(related_name='items', to='formidable.Field', on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -65,7 +65,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('slug', models.CharField(max_length=128)),
                 ('message', models.TextField(null=True, blank=True)),
-                ('form', models.ForeignKey(related_name='presets', to='formidable.Formidable')),
+                ('form', models.ForeignKey(related_name='presets', to='formidable.Formidable', on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
                 ('slug', models.CharField(max_length=128)),
                 ('value', models.CharField(max_length=128, null=True, blank=True)),
                 ('field_id', models.CharField(max_length=128, null=True, blank=True)),
-                ('preset', models.ForeignKey(related_name='arguments', to='formidable.Preset')),
+                ('preset', models.ForeignKey(related_name='arguments', to='formidable.Preset', on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -85,23 +85,23 @@ class Migration(migrations.Migration):
                 ('value', models.CharField(max_length=256)),
                 ('type', models.CharField(max_length=256)),
                 ('message', models.TextField(null=True, blank=True)),
-                ('field', models.ForeignKey(related_name='validations', to='formidable.Field')),
+                ('field', models.ForeignKey(related_name='validations', to='formidable.Field', on_delete=models.CASCADE)),
             ],
         ),
         migrations.AddField(
             model_name='field',
             name='form',
-            field=models.ForeignKey(related_name='fields', to='formidable.Formidable'),
+            field=models.ForeignKey(related_name='fields', to='formidable.Formidable', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='default',
             name='field',
-            field=models.ForeignKey(related_name='defaults', to='formidable.Field'),
+            field=models.ForeignKey(related_name='defaults', to='formidable.Field', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='access',
             name='field',
-            field=models.ForeignKey(related_name='accesses', to='formidable.Field'),
+            field=models.ForeignKey(related_name='accesses', to='formidable.Field', on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='field',

--- a/formidable/models.py
+++ b/formidable/models.py
@@ -79,7 +79,9 @@ class Field(models.Model):
 
     slug = models.CharField(max_length=256)
     label = models.CharField(max_length=256)
-    form = models.ForeignKey(Formidable, related_name='fields')
+    form = models.ForeignKey(
+        Formidable, related_name='fields', on_delete=models.CASCADE
+    )
     type_id = models.CharField(
         max_length=256,
         choices=FieldSerializerRegister.get_instance().to_choices()
@@ -106,7 +108,9 @@ class Field(models.Model):
 class Default(models.Model):
 
     value = models.CharField(max_length=256)
-    field = models.ForeignKey(Field, related_name='defaults')
+    field = models.ForeignKey(
+        Field, related_name='defaults', on_delete=models.CASCADE
+    )
 
     class Meta:
         app_label = 'formidable'
@@ -117,7 +121,9 @@ class Default(models.Model):
 
 @python_2_unicode_compatible
 class Item(models.Model):
-    field = models.ForeignKey(Field, related_name='items')
+    field = models.ForeignKey(
+        Field, related_name='items', on_delete=models.CASCADE
+    )
     value = models.TextField()
     label = models.TextField()
     order = models.IntegerField()
@@ -137,7 +143,9 @@ class Access(models.Model):
         unique_together = (('field', 'access_id'),)
         app_label = 'formidable'
 
-    field = models.ForeignKey(Field, related_name='accesses')
+    field = models.ForeignKey(
+        Field, related_name='accesses', on_delete=models.CASCADE
+    )
     access_id = models.CharField(max_length=128)
     level = models.CharField(max_length=128, choices=(
         (constants.REQUIRED, 'Required'), (constants.EDITABLE, 'Editable'),
@@ -151,7 +159,9 @@ class Access(models.Model):
 
 @python_2_unicode_compatible
 class Validation(models.Model):
-    field = models.ForeignKey(Field, related_name='validations')
+    field = models.ForeignKey(
+        Field, related_name='validations', on_delete=models.CASCADE
+    )
     value = models.CharField(max_length=256)
     type = models.CharField(max_length=256)
     message = models.TextField(blank=True, null=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     django111-py{27,35,36}-drf{38,39,310}-{sqlite,pg}
+    django22-py{35,36}-drf{39,310}-{sqlite,pg}
     spectest
     flake8
     isort-check
@@ -15,6 +16,7 @@ changedir = demo
 deps =
     ; Django versions
     django111: Django>=1.11,<1.12
+    django22: Django>=2.2,<2.3
     ; Python versions
     py27: django-perf-rec>=3,<4
     py{35,36}: django-perf-rec


### PR DESCRIPTION
Django Formidable should probably work on Django 2.0 and 2.1, but it's not in our test suite. We've decided to skip those versions because of their short-term support.

closes #326

## Review

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] Migration(s)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
