### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,11 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 3.3.0 (2019-11-29)
+==========================
 
 - Add support to Django 2.2 (#326).
-- Add support to Python 3.7 & 3.8.
+- Add support to Python 3.7 & 3.8 (#374).
 
 Release 3.2.0 (2019-11-07)
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+master (unreleased)
+===================
+
+Nothing here yet.
+
 Release 3.3.0 (2019-11-29)
 ==========================
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,12 +2,22 @@
 Deprecation timeline
 ====================
 
-From 3.2.0 to... ?
-==================
+From 3.2.0 to 3.3.0
+===================
 
-.. versionadded:: X.Y.Z
+Django versions
+---------------
+
+.. versionadded:: 3.3.0
 
     Added support for Django 2.2. Django Formidable should probably work on Django 2.0 and 2.1, but it's not in our test suite. We've decided to skip those versions because of their short-term support.
+
+Python versions
+---------------
+
+.. versionadded:: 3.3.0
+
+    Added support for Python 3.7 and 3.8
 
 
 From 3.1.0 to 3.2.0

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '3.3.0.dev0'
+version = '3.3.0'
 json_version = latest_version

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -3,5 +3,5 @@ from __future__ import absolute_import
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '3.3.0'
+version = '3.4.0.dev0'
 json_version = latest_version


### PR DESCRIPTION
- Add support to Django 2.2 (#326).
- Add support to Python 3.7 & 3.8 (#374).

## Release

* [x] Change `formidable.version` with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [x] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [x] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [x] Tag the appropiate commit with the appropriate tag (i.e. not the "back to dev one")
* [x] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
* [ ] Drop the branch
