### PR TITLE
Removed tox.ini directive that skipped missing Python interpreters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing here yet.
+- Removed ``tox.ini`` directive that skipped missing Python interpreters.
 
 Release 3.3.0 (2019-11-29)
 ==========================

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     flake8
     isort-check
 skipsdist = True
-skip_missing_interpreters = True
 
 [testenv]
 passenv = PGHOST PGDATABASE PGUSER PGPASSWORD PGPORT


### PR DESCRIPTION
## Review


* [x] Tests
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
