### PR TITLE
Pass context to serializer in from_json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
-Nothing to see here yet.
+- Pass context to serializer in from_json.
 
 Release 6.0.0 (2020-10-07)
 ==========================

--- a/demo/tests/test_forms.py
+++ b/demo/tests/test_forms.py
@@ -1,5 +1,5 @@
 import json
-import os
+from os.path import dirname, join
 
 from django import forms
 from django.core.exceptions import ValidationError
@@ -8,7 +8,7 @@ import django_perf_rec
 from freezegun import freeze_time
 
 from formidable.constants import REQUIRED, EDITABLE, READONLY, HIDDEN
-from formidable.models import Formidable
+from formidable.models import Formidable, get_serializer
 from formidable.forms import FormidableForm, widgets, fields
 
 
@@ -787,8 +787,10 @@ class FormidableModelTestCase(TestCase):
         We should have an instance of ``Formidable``.
 
         """
-        filepath = os.path.join(os.path.dirname(__file__),
-                                '../fixtures/augmentation_heures.json')
+        filepath = join(
+            dirname(__file__),
+            '../fixtures/augmentation_heures.json'
+        )
         with open(filepath) as f:
             schema_definition = json.load(f)
 
@@ -808,3 +810,20 @@ class FormidableModelTestCase(TestCase):
         self.assertEqual(len(context.exception.messages), 3)
         for message in context.exception.messages:
             self.assertEqual(message, 'This field is required.')
+
+    def test_get_serializer_with_context(self):
+        filepath = join(
+            dirname(__file__),
+            '../fixtures/augmentation_heures.json'
+        )
+        with open(filepath) as f:
+            schema_definition = json.load(f)
+
+        # get_serializer is a function that is called in from_json.
+        serializer = get_serializer(schema_definition)
+        self.assertEqual(serializer.context, {})
+
+        serializer = get_serializer(
+            schema_definition,
+            context={"hello": "world"})
+        self.assertEqual(serializer.context, {"hello": "world"})

--- a/formidable/models.py
+++ b/formidable/models.py
@@ -7,6 +7,17 @@ from formidable import constants
 from formidable.register import FieldSerializerRegister
 
 
+def get_serializer(definition_schema, context=None):
+    """
+    Return a FormidableSerializer instance, including eventual context.
+    """
+    from formidable.serializers import FormidableSerializer
+    serializer = FormidableSerializer(data=definition_schema)
+    # pass context to serializer so we can use it during data validation
+    serializer.context.update(context or {})  # If None, will default to {}
+    return serializer
+
+
 class Formidable(models.Model):
 
     label = models.CharField(max_length=256)
@@ -48,9 +59,8 @@ class Formidable(models.Model):
         <Formidable: Formidable object>
 
         """
-        from formidable.serializers import FormidableSerializer
-
-        serializer = FormidableSerializer(data=definition_schema)
+        context = kwargs.pop("context", {})
+        serializer = get_serializer(definition_schema, context)
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
 


### PR DESCRIPTION
We had issues with missing context in to_internal_value, when called
from `from_json` method.
This PR allows to pass a context to `from_json`. It will be given to the
serializer to be used in validations.

## Review

This PR closes #<!-- issue number -->

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
  * [ ] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [x] Migration(s)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch

<!-- THE FOLLOWING IS ONLY FOR A RELEASE PULL-REQUEST -->
<!-- uncomment the block to make it real

## Release

* [ ] Change `formidable.version` with the appropriate tag
* [ ] Amend `CHANGELOG.rst` (check the release date)
* [ ] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [ ] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [ ] Tag the appropriate commit with the appropriate tag (i.e. not the "back to dev one")
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI

-->
