### PR TITLE
v4.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 ChangeLog
 =========
 
-Release 4.0.2 (unreleased)
+Release 4.0.2 (2020-02-13)
 ==========================
 
 - HOTFIX: Allow empty values for ``defaults`` properties (#391).

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,5 +1,5 @@
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '4.0.1'
+version = '4.0.2'
 json_version = latest_version


### PR DESCRIPTION
- HOTFIX: Allow empty values for ``defaults`` properties (#391).

## Release

* [x] Change `formidable.version` with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [x] ~~DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"~~ no back to dev, this will be included in the transfer to master
* [ ] Tag the appropriate commit with the appropriate tag
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
