### PR TITLE
Warn integrators about incompatibilities with jsonfield & Django 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     docker:
       - image: themattrix/tox
       - image: circleci/postgres:latest
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
     working_directory: ~/django-formidable
     steps:
       - run:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ master (unreleased)
 
 - Drop support for Django REST Framework 3.8 (#382).
 - Ensure ``jsonfield`` compatibility check. Documentation is amended, and an ``ImportWarning`` is thrown as soon as you're using Django 1.11 (#395).
+- Fix Postgresql configuration in CircleCI regarding the authentication (#395).
 
 Release 4.0.2 (2020-02-13)
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Drop support for Django REST Framework 3.8 (#382).
+- Ensure ``jsonfield`` compatibility check. Documentation is amended, and an ``ImportWarning`` is thrown as soon as you're using Django 1.11 (#395).
 
 Release 4.0.2 (2020-02-13)
 ==========================

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,11 @@ Warnings
 * Django compatibility : Django 1.11, 2.2.
 * Django REST Framework : Compatible from the version 3.9.x to 3.10.x
 
+.. warning::
+
+    Versions of ``jsonfield`` beyond 3.x are incompatible with Django 1.11.
+    If you're still using Django 1.11, you'll have to freeze it with ``jsonfield<3`` in your project.
+
 See the `Deprecation timeline <http://django-formidable.readthedocs.io/en/latest/deprecations.html>`_ document for more information on deprecated versions.
 
 

--- a/demo/tests/test_app.py
+++ b/demo/tests/test_app.py
@@ -1,0 +1,27 @@
+import warnings
+
+from distutils.version import StrictVersion as version
+
+import django
+from django.apps import apps
+from django.test import TestCase
+
+
+class FormidableConfigTest(TestCase):
+    def test_apps(self):
+        config = apps.get_app_config('formidable')
+        self.assertEqual(config.name, 'formidable')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            config.ready()
+            # Verify some things
+            if version(django.get_version()) < version("2.0"):
+                # Django 1.11 mainly
+                assert len(w) == 1, w
+                test_warning = w[0]
+                assert issubclass(test_warning.category, ImportWarning)
+                assert "jsonfield" in str(test_warning.message)
+            else:
+                # No warning beyond Django 2.
+                assert len(w) == 0, w

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -9,6 +9,11 @@ From 4.0.1 to x.y.z
 
     Drop support for Django Rest Framework 3.8
 
+.. warning:: x.y.z
+
+    As of February 2020, several releases of the library ``jsonfield`` have broken the compatibility with Django 1.11.
+    As a consequence, if you want to use Django Formidable with Django 1.11, you'll have to make sure that you're freezing your requirements to ``jsonfield<3``.
+
 
 From 3.3.0 to 4.0.0
 ===================

--- a/formidable/app.py
+++ b/formidable/app.py
@@ -5,6 +5,10 @@ The :class:`FormidableConfig` checks various configuration settings:
 
 * post-update and post-create callbacks
 """
+import warnings
+from distutils.version import StrictVersion as version
+
+import django
 from django.apps import AppConfig
 
 
@@ -20,3 +24,11 @@ class FormidableConfig(AppConfig):
         """
         from .views import check_callback_configuration
         check_callback_configuration()
+        # Incompatibility between some version of jsonfield + Django.
+        if version(django.get_version()) < version("2.0"):
+            warnings.warn(
+                "If you're using Django<2.0, you must pin jsonfield version in"
+                " your requirements to ``jsonfield<3``. See deprecation"
+                " documentation for more details",
+                ImportWarning
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ deps =
     drf310: djangorestframework<3.11
     ; When testing with postgresql
     pg: psycopg2-binary
+
+    ; jsonfield compatibility with Django 1.11
+    django111: jsonfield<3
+
     ; Requirements from demo project
     -rdemo/requirements-demo.pip
 commands =


### PR DESCRIPTION
* A warning is raised,
* Deprecation documentation is amended,
* Readme is amended to warn the user about this potential runtime failure.

## Review

This PR closes #395

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
