### PR TITLE
Improve default values for readonly fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
+- Improve default values for readonly fields.
 - Applying isort v5+ changes: no ``--recursive flag``, removed the ``not_skip`` settings. (internal change, no runtime impact).
 
 Release 5.0.0 (2020-06-30)

--- a/demo/tests/test_defaults_with_accesses.py
+++ b/demo/tests/test_defaults_with_accesses.py
@@ -1,0 +1,93 @@
+from django.test import TestCase
+from formidable.forms import (
+    FormidableForm, fields
+)
+from formidable import constants
+from formidable.forms import get_dynamic_form_class
+
+
+class AccessesTestCaseTestForm(FormidableForm):
+    editable_text = fields.CharField(
+        label='Editable text',
+        accesses={'jedi': constants.EDITABLE},
+        default='Default value (editable)'
+    )
+    readonly_text = fields.CharField(
+        label='Readonly text',
+        accesses={'jedi': constants.READONLY},
+        default='Default value (readonly)'
+    )
+    readonly_dropdown = fields.MultipleChoiceField(
+        label='Readonly dropdown',
+        accesses={'jedi': constants.READONLY},
+        defaults=['val1', 'val2'],
+        choices=[
+            ('val1', 'Default value 1 (readonly)'),
+            ('val2', 'Default value 2 (readonly)'),
+            ('val3', 'Value 3')]
+    )
+    hidden_field = fields.CharField(
+        label='Hidden text',
+        accesses={'jedi': constants.HIDDEN},
+        default='Default value (hidden)'
+    )
+
+
+class AccessesTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        form_class = AccessesTestCaseTestForm
+        self.formidable = form_class.to_formidable(label='title')
+
+    def test_readonly_field_with_default_filled(self):
+        form_class = get_dynamic_form_class(self.formidable, 'jedi')
+        data = {
+            'editable_text': 'Default value (editable)',
+            'readonly_text': 'Default value (readonly)',
+            'readonly_dropdown': ['val1', 'val2'],
+            'hidden_text': 'Default value (hidden)'
+        }
+
+        form = form_class(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data, {
+            'editable_text': 'Default value (editable)',
+            'readonly_text': 'Default value (readonly)',
+            'readonly_dropdown': ['val1', 'val2'],
+
+        })
+
+    def test_readonly_field_with_default_empty(self):
+        form_class = get_dynamic_form_class(self.formidable, 'jedi')
+        data = {
+            'editable_text': '',
+            'readonly_text': '',
+            'readonly_dropdown': '',
+            'hidden_text': ''
+        }
+
+        form = form_class(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data, {
+            'editable_text': '',
+            'readonly_dropdown': ['val1', 'val2'],
+            'readonly_text': 'Default value (readonly)'
+        })
+
+    def test_readonly_field_with_default_filled_other(self):
+        form_class = get_dynamic_form_class(self.formidable, 'jedi')
+        data = {
+            'editable_text': '',
+            'readonly_text': 'Wrong value',
+            'readonly_dropdown': ['wrong', 'value'],
+            'hidden_text': 'Wrong value'
+        }
+
+        form = form_class(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data, {
+            'editable_text': '',
+            'readonly_dropdown': ['val1', 'val2'],
+            'readonly_text': 'Default value (readonly)'
+        })

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.forms.fields import MultipleChoiceField
 
 from formidable.forms import fields
 from formidable.utils import import_object
@@ -59,6 +60,7 @@ class FieldBuilder:
             'help_text': self.get_help_text(),
             'validators': self.get_validators(),
             'disabled': self.get_disabled(),
+            'initial': self.get_initial()
         }
 
         kwargs['widget'] = self.get_widget(default_widget_class)
@@ -91,6 +93,23 @@ class FieldBuilder:
             return self.access.level == 'READONLY'
 
         return False
+
+    def get_initial(self):
+        if self.field_is_dict and 'defaults' in self.field:
+            defaults = self.field['defaults']
+            if len(defaults) > 0:
+                if (self.field_class == MultipleChoiceField
+                        or self.field.get('multiple', False)):
+                    return defaults
+                return defaults[0]
+        elif hasattr(self.field, 'defaults'):
+            defaults = self.field.defaults.all()
+            if len(defaults) > 0:
+                if (self.field_class == MultipleChoiceField
+                        or getattr(self.field, 'multiple', False)):
+                    return list(defaults)
+                return defaults[0]
+        return None
 
     def get_required(self):
         if self.field_is_dict:


### PR DESCRIPTION
Issue: default values for readonly fields are cleaned, we want to keep them.

## Review

* [x] Tests<!-- mandatory -->
* [ ] Docs/comments
  * [ ] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [x] Migration(s)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch

<!-- THE FOLLOWING IS ONLY FOR A RELEASE PULL-REQUEST -->
<!-- uncomment the block to make it real

## Release

* [ ] Change `formidable.version` with the appropriate tag
* [ ] Amend `CHANGELOG.rst` (check the release date)
* [ ] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [ ] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [ ] Tag the appropriate commit with the appropriate tag (i.e. not the "back to dev one")
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI

-->
