### PR TITLE
Dropped support for Python 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ jobs:
   docs:
     working_directory: ~/django-formidable
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:lts-buster
     steps:
       - checkout
       - run:
           name: Check Python version & install Python dependencies
           command: |
-            python --version
+            python3 --version
             sudo apt update && sudo apt install python-pip python-dev
       - run:
           name: Run Sphinx doc tests using tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
+- Drop support for Python 3.5 (EOL: 2020-09-13).
 - Fix defaults on readonly fields during validation from schema
 - Fix default values for readonly date fields.
 - Improve default values for readonly fields.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ edit, delete and use forms.
 Warnings
 ========
 
-* Python Compatibility : 3.5, 3.6, 3.7, 3.8
+* Python Compatibility : 3.6, 3.7, 3.8
 * Django compatibility : Django 2.2.
 * Django REST Framework : Compatible from the version 3.9.x to 3.10.x
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,6 +2,16 @@
 Deprecation timeline
 ====================
 
+From 5.0.0 to 6.0.0
+===================
+
+Python versions
+---------------
+
+.. deprecated:: 6.0.0
+
+    Drop support for Python 3.5
+
 From 4.0.1 to 5.0.0
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author='Guillaume Camera, Guillaume Gérard',
     author_email='guillaume.camera@people-doc.com, '
                  'guillaume.gerard@people-doc.com',
+    python_requires=">=3.6",
     install_requires=[
         'Django',
         'djangorestframework<4.0.0',
@@ -34,7 +35,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    django22-py{35,36,37,38}-drf{39,310}-{sqlite,pg}
+    django22-py{36,37,38}-drf{39,310}-{sqlite,pg}
     spectest
     flake8
     isort-check


### PR DESCRIPTION
## Review


* [x] Tests -- no regression / only Python 3.6+ tests are executed
* [x] Doc to be built using Python 3.6
* [x] Docs/comments
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
