### PR TITLE
Fix defaults on readonly during validation from schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ ChangeLog
 master (unreleased)
 ===================
 
+- Fix defaults on readonly fields during validation from schema
 - Fix default values for readonly date fields.
 - Improve default values for readonly fields.
 - Applying isort v5+ changes: no ``--recursive flag``, removed the ``not_skip`` settings. (internal change, no runtime impact).

--- a/formidable/forms/field_builder.py
+++ b/formidable/forms/field_builder.py
@@ -96,7 +96,7 @@ class FieldBuilder:
 
     def get_initial(self):
         if self.field_is_dict and 'defaults' in self.field:
-            defaults = self.field['defaults']
+            defaults = [x for x in self.field['defaults'] if x]
             if len(defaults) > 0:
                 if (self.field_class == MultipleChoiceField
                         or self.field.get('multiple', False)):


### PR DESCRIPTION
Something was missing in the last PR, the validation from schema was still broken in case of empty defaults.

## Review

This PR closes #<!-- issue number -->

* [x] Tests<!-- mandatory -->
* [x] Docs/comments
  * [ ] *IN CASE YOU'VE CHANGED THE `formidable.yml` file*: run ``tox -e swagger-statics`` to rebuild the swagger static files **and** commit the diff.
* [x] Migration(s)
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch

<!-- THE FOLLOWING IS ONLY FOR A RELEASE PULL-REQUEST -->
<!-- uncomment the block to make it real

## Release

* [ ] Change `formidable.version` with the appropriate tag
* [ ] Amend `CHANGELOG.rst` (check the release date)
* [ ] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [ ] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [ ] Tag the appropriate commit with the appropriate tag (i.e. not the "back to dev one")
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI

-->
