### PR TITLE
Fix license reference in setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ master (unreleased)
 ===================
 
 - Pass context to serializer in from_json.
+- Fix license reference in setup.py (#402).
 
 Release 6.0.0 (2020-10-07)
 ==========================

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=formidable.version,
     packages=find_packages(),
     include_package_data=True,
-    license='BSD License',
+    license='MIT License',
     description='django-formidable is a full django application which '
                 'allows you to create, edit, delete and use forms.',
     long_description=README,


### PR DESCRIPTION
It said BSD, while it was MIT since the beginning. Thx @jayvdb for the heads-up!



## Review

This PR closes #402

* [x] Tests<!-- mandatory -->
* [x] `CHANGELOG.rst` Updated
* [ ] Delete your branch
