### PR TITLE
Release 7.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 ChangeLog
 =========
 
+master (unreleased)
+==================
+
+Nothing to see here.
+
 Release 7.0.0 (2021-03-11)
 ==========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 ChangeLog
 =========
 
-master (unreleased)
-===================
+Release 7.0.0 (2021-03-11)
+==========================
 
 - Allow empty description on ``Formidable`` model
 

--- a/docs/source/deprecations.rst
+++ b/docs/source/deprecations.rst
@@ -2,10 +2,10 @@
 Deprecation timeline
 ====================
 
-From 6.1.0 to <x.y.z>
-=====================
+From 6.1.0 to 7.0.0
+===================
 
-.. versionadded:: <x.y.z>
+.. versionadded:: <7.0.0>
 
     The `description` field in the ``Formidable`` model class would now allow empty values.
 

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,5 +1,5 @@
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '6.2.0.dev0'
+version = '7.0.0'
 json_version = latest_version

--- a/formidable/__init__.py
+++ b/formidable/__init__.py
@@ -1,5 +1,5 @@
 from .json_migrations import latest_version
 
 default_app_config = 'formidable.app.FormidableConfig'
-version = '7.0.0'
+version = '7.1.0.dev0'
 json_version = latest_version


### PR DESCRIPTION
Even though this change is not *breaking* (because forms generated prior to 7.0.0 would still work), this version is marked as a major release. Because it changes the database schema, and implies a database migration.



## Release

* [x] Change `formidable.version` with the appropriate tag
* [x] Amend `CHANGELOG.rst` (check the release date)
* [x] *If the version deprecates one or more feature(s)* check the docs `deprecations.rst` file and change it if necessary.
* [x] DON'T FORGET TO MAKE THE "BACK TO DEV COMMIT"
* [x] Tag the appropriate commit with the appropriate tag (i.e. not the "back to dev one")
* [ ] Merge (fast forward is nice)
* [ ] Push the tag (using: `git push --tags`)
* [ ] Edit the release (copy/paste CHANGELOG)
* [ ] Publish the new release to PyPI
